### PR TITLE
add terminate option to reload

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func main() {
 
 func realMain() int {
 	var errExit bool
-	var reload bool
+	var reload string
 	var consulAddr string
 	var consulDC string
 	var sanitize bool
@@ -23,9 +23,10 @@ func realMain() int {
 	flag.BoolVar(
 		&errExit, "errexit", false,
 		"exit if there is an error watching config keys")
-	flag.BoolVar(
-		&reload, "reload", false,
-		"if set, restarts the process when config changes")
+	flag.StringVar(
+		&reload, "reload", "false",
+	  `if true, restarts the process when config change
+			if terminate, kills the process when config change`)
 	flag.StringVar(
 		&consulAddr, "addr", "127.0.0.1:8500",
 		"consul HTTP API address with port")
@@ -42,6 +43,16 @@ func realMain() int {
 	if flag.NArg() < 2 {
 		flag.Usage()
 		return 1
+	}
+	reloadOpts := map[string]bool {
+		"true": true,
+		"false": true,
+		"terminate": true,
+	}
+	if !reloadOpts[reload] {
+		fmt.Println("Invalid value for -reload. Possible values are true, false, and terminate")
+    flag.Usage()
+		return 111
 	}
 
 	args := flag.Args()

--- a/watch.go
+++ b/watch.go
@@ -20,7 +20,7 @@ type WatchConfig struct {
 	Cmd        []string
 	ErrExit    bool
 	Prefix     string
-	Reload     bool
+	Reload     string
 	Sanitize   bool
 	Upcase     bool
 }
@@ -95,7 +95,7 @@ func watchAndExec(config *WatchConfig) (int, error) {
 
 		// Configuration changed, reload the process.
 		if cmd != nil {
-			if !config.Reload {
+			if config.Reload == "false" {
 				// We don't want to reload the process... just ignore.
 				continue
 			}
@@ -123,6 +123,11 @@ func watchAndExec(config *WatchConfig) (int, error) {
 			}
 
 			cmd = nil
+
+			if config.Reload == "terminate" {
+				exitCh <- 0
+				return 0, err
+			}
 		}
 
 		processEnv := os.Environ()
@@ -174,7 +179,7 @@ func watch(
 	errCh chan<- error,
 	quitCh <-chan struct{},
 	errExit bool,
-	watch bool) {
+	watch string) {
 	// Get the initial list of k/v pairs. We don't do a retryableList
 	// here because we want a fast fail if the initial request fails.
 	pairs, meta, err := client.KV().List(prefix, nil)
@@ -187,7 +192,7 @@ func watch(
 	pairCh <- pairs
 
 	// If we're not watching, just return right away
-	if !watch {
+	if watch == "false" {
 		return
 	}
 


### PR DESCRIPTION
Using `-reload=terminate` will cause the running command to be killed and not restarted when a config change is seen.
