### PR TITLE
add terminate option to reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  * Do not reload command if -reload=terminate
+
 ## 0.2.0 (July 16, 2014)
 
   * Sanitize and upcase by default


### PR DESCRIPTION
Using -reload=terminate will cause the running command to be killed and not restarted when a config change is seen.
