### PR TITLE
Add support for encrypted values.

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func realMain() int {
 	var timeout time.Duration
 	var consulAddr string
 	var consulDC string
+	var keystore string
 	var sanitize bool
 	var upcase bool
 	flag.Usage = usage
@@ -41,6 +42,9 @@ func realMain() int {
 	flag.StringVar(
 		&consulDC, "dc", "",
 		"consul datacenter, uses local if blank")
+	flag.StringVar(
+		&keystore, "keystore", "",
+		"directory of keys used for decryption")
 	flag.BoolVar(
 		&sanitize, "sanitize", true,
 		"turn invalid characters in the key into underscores")
@@ -63,6 +67,7 @@ func realMain() int {
 		Reload:     reload,
 		Terminate:  terminate,
 		Timeout:    timeout,
+		Keystore:   keystore,
 		Sanitize:   sanitize,
 		Upcase:     upcase,
 	}

--- a/watch.go
+++ b/watch.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/armon/consul-api"
+	"github.com/ryanbreen/gocrypt"
 )
 
 // Configuration for watches.
@@ -23,6 +24,7 @@ type WatchConfig struct {
 	Reload     bool
 	Terminate  bool
 	Timeout    time.Duration
+	Keystore   string
 	Sanitize   bool
 	Upcase     bool
 }
@@ -83,7 +85,13 @@ func watchAndExec(config *WatchConfig) (int, error) {
 			if config.Upcase {
 				k = strings.ToUpper(k)
 			}
-			newEnv[k] = string(pair.Value)
+
+			v, err := gocrypt.DecryptTags(pair.Value, config.Keystore)
+			if (err != nil) {
+				v = pair.Value
+			}
+
+			newEnv[k] = string(v)
 		}
 
 		// If the environmental variables didn't actually change,


### PR DESCRIPTION
gocrypt is a library I wrote to wrap values in AES 256-bit GCM encryption.  The user encrypts the value using a key known only to them and a subset of systems on which envconsul runs.  The value is decrypted after it is pulled from Consul and before it is exported into the environment.

This end-to-end encryption of values is useful for secure environments, such as cardholder environments, where there are fairly stringent restrictions on who should be able to read critical data such as passwords and DB connection strings.  With this support in place, we can safely check our configuration data into Git, place it in Consul KVs, and trust that only the correct machines can see the plaintext values.
