### PR TITLE
Don't panic if the connection to the Consul agent dies.

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -221,8 +221,14 @@ func watch(
 			}
 		}
 
-		pairCh <- pairs
-		curIndex = meta.LastIndex
+		if meta == nil {
+			// This happens when the connection to the consul agent dies.  Build in a retry by looping after a delay.
+			fmt.Println("Error communicating with consul agent.")
+			time.Sleep(time.Duration(5) * time.Second)
+		} else {
+			pairCh <- pairs
+			curIndex = meta.LastIndex
+		}
 	}
 }
 


### PR DESCRIPTION
This tests the meta value before accessing it.  If the connection to Consul dies, meta will be nil, and the previous version would panic.
