### PR TITLE
Update to use new watcher API as of commit 2cbf5d1524

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -175,12 +175,16 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	log.Printf("[DEBUG] (cli) creating Watcher")
-	watcher, err := watch.NewWatcher(client, runner.Dependencies())
+	watcher, err := watch.NewWatcher(client, once)
 	if err != nil {
 		return cli.handleError(err, ExitCodeWatcherError)
 	}
 
-	go watcher.Watch(once)
+	for _, dep := range runner.Dependencies() {
+		if _, err := watcher.Add(dep); err != nil {
+			return cli.handleError(err, ExitCodeWatcherError)
+		}
+	}
 
 	var minTimer, maxTimer <-chan time.Time
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -203,7 +203,6 @@ func TestRunner_runExitCh(t *testing.T) {
 
 	runner.Receive(pair)
 	runner.Run()
-	go runner.Wait()
 
 	select {
 	case <-runner.ExitCh:


### PR DESCRIPTION
This updates cli to use new watcher API as of https://github.com/hashicorp/consul-template/commit/2cbf5d1524f9620d94accd08fa2e4f6a6e96cdd6

Also fix a race in `runner_test` which randomly fails on my machine.