### PR TITLE
Support multiple prefixes and propagate signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ Usage
 
 \* = Required parameter
 
+Multiple prefixes are merged in the order they are specified, with the right-most prefix taking precedence over its left siblings. For example, consider:
+
+```shell
+envconsul -prefix global/config -prefix redis/config
+```
+
+In this example, the values of `redis` take precedence over the values in `global`. If they had the following structure:
+
+```text
+# Global
+A=1
+B=1
+C=1
+
+# Redis
+A=2
+```
+
+The resulting environment would be:
+
+```text
+A=2
+B=1
+C=1
+```
+
 ### Command Line
 The CLI interface supports all of the options detailed above.
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,17 @@ $ envconsul -log-level debug ...
 # ...
 ```
 
+Quiescence
+----------
+If you have a large number of services that are in flux, you may want to specify a quiescence timer. This will prevent commands from running until a stable state is reached (or a maximum timeout you specify). You can specify the quiescence interval using the `-wait` flag on the command line:
+
+```shell
+envconsul -wait "10s:50s"
+```
+
+This tells envconsul to wait for a period of 10 seconds while we do not have data before running/restarting the command, but to wait no more than 50 seconds.
+
+
 Contributing
 ------------
 To hack on envconsul, you will need a modern [Go][] environment. To compile the `envconsul` binary and run the test suite, simply execute:

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Usage
 | `token`           | The [Consul API token][Consul ACLs]. There is no default value.
 | `wait`            | The `minimum(:maximum)` to wait before rendering a command to fire, separated by a colon (`:`). If the optional maximum value is omitted, it is assumed to be 4x the required minimum value. There is no default value.
 | `retry`           | The amount of time to wait if Consul returns an error when communicating with the API. The default value is 5 seconds.
-| `sanitize`        | Replace invalid characters in keys to underscores |
-| `upcase`          | Convert all environment variable keys to uppercase |
+| `prefix`          | A prefix to watch in Consul. This may be specified multiple times.
+| `sanitize`        | Replace invalid characters in keys to underscores .
+| `upcase`          | Convert all environment variable keys to uppercase.
 | `config`          | The path to a configuration file or directory of configuration files on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file. There is no default value.
 | `log-level`       | The log level for output. This applies to the stdout/stderr logging as well as syslog logging (if enabled). Valid values are "debug", "info", "warn", and "err". The default value is "warn".
 | `once`            | Run envconsul once and exit (as opposed to the default behavior of daemon). _(CLI-only)_
@@ -85,6 +86,8 @@ max_stale = "10m"
 timeout = "5s"
 retry = "10s"
 sanitize = true
+
+prefixes = ["config/global", "config/redis"]
 
 auth {
   enabled = true

--- a/cli.go
+++ b/cli.go
@@ -242,6 +242,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, []string, bool, bool, error)
 	flags.StringVar(&config.Syslog.Facility, "syslog-facility", config.Syslog.Facility, "")
 	flags.Var((*watch.WaitVar)(config.Wait), "wait", "")
 	flags.DurationVar(&config.Retry, "retry", config.Retry, "")
+	flags.Var((*prefixVar)(&config.Prefixes), "prefix", "")
 	flags.BoolVar(&config.Sanitize, "sanitize", config.Sanitize, "")
 	flags.BoolVar(&config.Upcase, "upcase", config.Upcase, "")
 	flags.StringVar(&config.Path, "config", config.Path, "")
@@ -293,6 +294,9 @@ Options:
   -retry=<duration>        The amount of time to wait if Consul returns an
                            error when communicating with the API
 
+  -prefix                  A prefix to watch, multiple prefixes are merged from
+                           left to right, with the right-most result taking
+                           precedence
   -sanitize                Replace invalid characters in keys to underscores
   -upcase                  Convert all environment variable keys to uppercase
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -277,6 +277,36 @@ func TestParseFlags_prefixes(t *testing.T) {
 	}
 }
 
+func TestParseFlags_sanitize(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-sanitize",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := true
+	if config.Sanitize != expected {
+		t.Errorf("expected %t to be %t", config.Sanitize, expected)
+	}
+}
+
+func TestParseFlags_upcase(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-upcase",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := true
+	if config.Upcase != expected {
+		t.Errorf("expected %t to be %t", config.Upcase, expected)
+	}
+}
+
 func TestParseFlags_once(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	_, _, once, _, err := cli.parseFlags([]string{

--- a/cli_test.go
+++ b/cli_test.go
@@ -434,7 +434,7 @@ func TestRun_onceFlag(t *testing.T) {
 	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
 	cli := NewCLI(outStream, errStream)
 
-	command := "envconsul -consul demo.consul.io -once global/time sh -c ':'"
+	command := "envconsul -consul demo.consul.io -once -prefix global/time env"
 	args := strings.Split(command, " ")
 
 	ch := make(chan int, 1)

--- a/cli_test.go
+++ b/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	dep "github.com/hashicorp/consul-template/dependency"
 	"github.com/hashicorp/consul-template/watch"
 )
 
@@ -248,6 +249,31 @@ func TestParseFlags_retry(t *testing.T) {
 	expected := 10 * time.Hour
 	if config.Retry != expected {
 		t.Errorf("expected %v to be %v", config.Retry, expected)
+	}
+}
+
+func TestParseFlags_prefixes(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-prefix", "config/global", "-prefix", "config/redis",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	globalDep, err := dep.ParseStoreKeyPrefix("config/global")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	redisDep, err := dep.ParseStoreKeyPrefix("config/redis")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []*dep.StoreKeyPrefix{globalDep, redisDep}
+	if !reflect.DeepEqual(config.Prefixes, expected) {
+		t.Errorf("expected %v to be %v", config.Prefixes, expected)
 	}
 }
 

--- a/flags.go
+++ b/flags.go
@@ -3,7 +3,38 @@ package main
 import (
 	"fmt"
 	"strings"
+
+	dep "github.com/hashicorp/consul-template/dependency"
 )
+
+// prefixVar implements the Flag.Value interface and allows the user
+// to specify multiple -prefix keys in the CLI where each option is parsed
+// as a dependency.
+type prefixVar []*dep.StoreKeyPrefix
+
+func (pv *prefixVar) Set(value string) error {
+	prefix, err := dep.ParseStoreKeyPrefix(value)
+	if err != nil {
+		return err
+	}
+
+	if *pv == nil {
+		*pv = make([]*dep.StoreKeyPrefix, 0, 1)
+	}
+	*pv = append(*pv, prefix)
+
+	return nil
+}
+
+func (pv *prefixVar) String() string {
+	list := make([]string, 0, len(*pv))
+	for _, prefix := range *pv {
+		list = append(list, prefix.Prefix)
+	}
+	return strings.Join(list, ", ")
+}
+
+/// ------------------------- ///
 
 // authVar implements the Flag.Value interface and allows the user to specify
 // authentication in the username[:password] form.

--- a/runner.go
+++ b/runner.go
@@ -115,7 +115,7 @@ func (r *Runner) Start() {
 			}
 
 			// If we are waiting for quiescence, setup the timers
-			if r.config.Wait != nil {
+			if r.config.Wait.Min != 0 && r.config.Wait.Max != 0 {
 				log.Printf("[INFO] (runner) quiescence timers starting")
 				r.minTimer = time.After(r.config.Wait.Min)
 				if r.maxTimer == nil {
@@ -191,6 +191,8 @@ func (r *Runner) Signal(sig os.Signal) error {
 // Run executes and manages the child process with the correct environment. The
 // current enviornment is also copied into the child process environment.
 func (r *Runner) Run() error {
+	log.Printf("[INFO] (runner) running")
+
 	env := make(map[string]string)
 
 	// Iterate over each dependency and pull out its data. If any dependencies do

--- a/runner.go
+++ b/runner.go
@@ -159,6 +159,13 @@ func (r *Runner) Start() {
 func (r *Runner) Stop() {
 	log.Printf("[INFO] (runner) stopping")
 	r.watcher.Stop()
+
+	// Stop the process if it is running
+	if r.cmd != nil {
+		log.Printf("[DEBUG] (runner) killing child process")
+		r.killProcess()
+	}
+
 	close(r.DoneCh)
 }
 
@@ -239,7 +246,7 @@ func (r *Runner) Run() error {
 
 	// Restart the current process if it exists
 	if r.cmd != nil && r.cmd.Process != nil {
-		r.restartProcess()
+		r.killProcess()
 	}
 
 	// Create a new environment
@@ -328,7 +335,7 @@ func (r *Runner) init() error {
 
 // Restart the current process in the Runner by sending a SIGTERM. It is
 // assumed that the process is set on the Runner!
-func (r *Runner) restartProcess() {
+func (r *Runner) killProcess() {
 	// Kill the process
 	exited := false
 

--- a/runner.go
+++ b/runner.go
@@ -265,6 +265,8 @@ func (r *Runner) Run() (<-chan int, error) {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("%s=%s", k, v))
 	}
 
+	// Create the command
+	log.Printf("[INFO] (runner) running command %s %s", r.command[0], strings.Join(r.command[1:], " "))
 	cmd := exec.Command(r.command[0], r.command[1:]...)
 	cmd.Stdout = r.outStream
 	cmd.Stderr = r.errStream

--- a/runner_test.go
+++ b/runner_test.go
@@ -114,14 +114,15 @@ func TestRun_sanitize(t *testing.T) {
 
 	runner.Receive(prefix, pair)
 
-	if err := runner.Run(); err != nil {
+	exitCh, err := runner.Run()
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	select {
 	case err := <-runner.ErrCh:
 		t.Fatal(err)
-	case <-runner.ExitCh:
+	case <-exitCh:
 		expected := "b_a_r=baz"
 		if !strings.Contains(outStream.String(), expected) {
 			t.Fatalf("expected %q to include %q", outStream.String(), expected)
@@ -157,14 +158,15 @@ func TestRun_upcase(t *testing.T) {
 
 	runner.Receive(prefix, pair)
 
-	if err := runner.Run(); err != nil {
+	exitCh, err := runner.Run()
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	select {
 	case err := <-runner.ErrCh:
 		t.Fatal(err)
-	case <-runner.ExitCh:
+	case <-exitCh:
 		expected := "BAR=baz"
 		if !strings.Contains(outStream.String(), expected) {
 			t.Fatalf("expected %q to include %q", outStream.String(), expected)
@@ -199,14 +201,15 @@ func TestRun_exitCh(t *testing.T) {
 
 	runner.Receive(prefix, pair)
 
-	if err := runner.Run(); err != nil {
+	exitCh, err := runner.Run()
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	select {
 	case err := <-runner.ErrCh:
 		t.Fatal(err)
-	case <-runner.ExitCh:
+	case <-exitCh:
 		// Ok
 	}
 }
@@ -258,15 +261,21 @@ func TestRun_merges(t *testing.T) {
 	}
 	runner.Receive(redisPrefix, redisData)
 
-	if err := runner.Run(); err != nil {
+	exitCh, err := runner.Run()
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	select {
 	case err := <-runner.ErrCh:
 		t.Fatal(err)
-	case <-runner.ExitCh:
-		expected := "ADDRESS=1.2.3.4\nPORT=8000"
+	case <-exitCh:
+		expected := "ADDRESS=1.2.3.4"
+		if !strings.Contains(outStream.String(), expected) {
+			t.Fatalf("expected %q to include %q", outStream.String(), expected)
+		}
+
+		expected = "PORT=8000"
 		if !strings.Contains(outStream.String(), expected) {
 			t.Fatalf("expected %q to include %q", outStream.String(), expected)
 		}

--- a/signals.go
+++ b/signals.go
@@ -1,0 +1,41 @@
+// +build linux darwin freebsd openbsd solaris netbsd
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var Signals = []os.Signal{
+	// POSIX.1-1990 standard
+	syscall.SIGHUP,  // Hangup detected on controlling terminalor death of controlling process
+	syscall.SIGINT,  // Interrupt from keyboard
+	syscall.SIGQUIT, // Quit from keyboard
+	syscall.SIGILL,  // Illegal Instruction
+	syscall.SIGABRT, // Abort signal from abort(3)
+	syscall.SIGFPE,  // Floating point exception
+	// syscall.SIGKILL, // Kill signal
+	syscall.SIGSEGV, // Invalid memory reference
+	syscall.SIGPIPE, // Broken pipe: write to pipe with no readers
+	syscall.SIGALRM, // Timer signal from alarm(2)
+	syscall.SIGTERM, // Termination signal
+	syscall.SIGUSR1, // User-defined signal 1
+	syscall.SIGUSR2, // User-defined signal 2
+	syscall.SIGCHLD, // Child stopped or terminated
+	syscall.SIGCONT, // Continue if stopped
+	// syscall.SIGSTOP, // Stop process
+	syscall.SIGTSTP, // Stop typed at tty
+	syscall.SIGTTIN, // tty input for background process
+	syscall.SIGTTOU, // tty output for background process
+
+	// Described in  SUSv2 and POSIX.1-2001
+	syscall.SIGBUS,    // Bus error (bad memory access)
+	syscall.SIGPROF,   // Profiling timer expired
+	syscall.SIGSYS,    // Bad argument to routine (SVr4)
+	syscall.SIGTRAP,   // Trace/breakpoint trap
+	syscall.SIGURG,    // Urgent condition on socket (4.2BSD)
+	syscall.SIGVTALRM, // Virtual alarm clock (4.2BSD)
+	syscall.SIGXCPU,   // CPU time limit exceeded (4.2BSD)
+	syscall.SIGXFSZ,   // File size limit exceeded (4.2BSD)
+}

--- a/signals.go
+++ b/signals.go
@@ -8,34 +8,10 @@ import (
 )
 
 var Signals = []os.Signal{
-	// POSIX.1-1990 standard
 	syscall.SIGHUP,  // Hangup detected on controlling terminalor death of controlling process
 	syscall.SIGINT,  // Interrupt from keyboard
 	syscall.SIGQUIT, // Quit from keyboard
-	syscall.SIGILL,  // Illegal Instruction
-	syscall.SIGABRT, // Abort signal from abort(3)
-	syscall.SIGFPE,  // Floating point exception
-	// syscall.SIGKILL, // Kill signal
-	syscall.SIGSEGV, // Invalid memory reference
-	syscall.SIGPIPE, // Broken pipe: write to pipe with no readers
-	syscall.SIGALRM, // Timer signal from alarm(2)
 	syscall.SIGTERM, // Termination signal
 	syscall.SIGUSR1, // User-defined signal 1
 	syscall.SIGUSR2, // User-defined signal 2
-	syscall.SIGCHLD, // Child stopped or terminated
-	syscall.SIGCONT, // Continue if stopped
-	// syscall.SIGSTOP, // Stop process
-	syscall.SIGTSTP, // Stop typed at tty
-	syscall.SIGTTIN, // tty input for background process
-	syscall.SIGTTOU, // tty output for background process
-
-	// Described in  SUSv2 and POSIX.1-2001
-	syscall.SIGBUS,    // Bus error (bad memory access)
-	syscall.SIGPROF,   // Profiling timer expired
-	syscall.SIGSYS,    // Bad argument to routine (SVr4)
-	syscall.SIGTRAP,   // Trace/breakpoint trap
-	syscall.SIGURG,    // Urgent condition on socket (4.2BSD)
-	syscall.SIGVTALRM, // Virtual alarm clock (4.2BSD)
-	syscall.SIGXCPU,   // CPU time limit exceeded (4.2BSD)
-	syscall.SIGXFSZ,   // File size limit exceeded (4.2BSD)
 }

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -1,0 +1,14 @@
+// +build windows plan9
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var Signals = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGTERM,
+	syscall.SIGQUIT,
+}


### PR DESCRIPTION
- Adds support for multiple prefixes
- Propagates select signals to child processes

This adds the `-prefix` multi-flag as discussed in #27.

- Fixes #27 
- Fixes #31 