### PR TITLE
Kill signal configurable

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -192,11 +192,15 @@ func (cli *CLI) parseFlags(args []string) (*Config, []string, bool, bool, error)
 	flags.StringVar(&config.LogLevel, "log-level", config.LogLevel, "")
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&version, "version", false, "")
+	flags.StringVar(&config.KillSigRaw, "killsig", config.KillSigRaw, "")
 
 	// If there was a parser error, stop
 	if err := flags.Parse(args); err != nil {
 		return nil, nil, false, false, err
 	}
+
+	// Verify and set the killsignal
+	config.verifyKillSig()
 
 	return config, flags.Args(), once, version, nil
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -452,5 +453,20 @@ func TestRun_onceFlag(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Errorf("expected data, but nothing was returned")
+	}
+}
+
+func TestParseFlags_killsigFlag(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-killsig", "SIGHUP",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := syscall.SIGHUP
+	if config.KillSig != expected {
+		t.Errorf("expected %q to be %q", config.KillSig, expected)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -145,6 +146,20 @@ func TestMerge_SyslogOptions(t *testing.T) {
 	}
 }
 
+func TestMerge_KillSig(t *testing.T) {
+	config := &Config{
+		KillSigRaw: "SIGQUIT",
+	}
+	otherConfig := &Config{
+		KillSigRaw: "SIGUSR1",
+	}
+	config.Merge(otherConfig)
+
+	if config.KillSig != syscall.SIGUSR1 {
+		t.Errorf("expected %+v to be %+v", config.KillSig, syscall.SIGUSR1)
+	}
+}
+
 // Test that file read errors are propagated up
 func TestParseConfig_readFileError(t *testing.T) {
 	_, err := ParseConfig(path.Join(os.TempDir(), "config.json"))
@@ -204,6 +219,7 @@ func TestParseConfig_correctValues(t *testing.T) {
     wait = "5s:10s"
     retry = "10s"
     log_level = "warn"
+    killsig = "SIGHUP"
 
     prefixes = ["global/config", "redis/config"]
 
@@ -290,6 +306,8 @@ func TestParseConfig_correctValues(t *testing.T) {
 		Retry:    10 * time.Second,
 		RetryRaw: "10s",
 		LogLevel: "warn",
+		KillSig: syscall.SIGHUP,
+		KillSigRaw: "SIGHUP",
 	}
 
 	if !reflect.DeepEqual(config, expected) {

--- a/runner.go
+++ b/runner.go
@@ -349,7 +349,7 @@ func (r *Runner) killProcess() {
 	// Kill the process
 	exited := false
 
-	if err := r.cmd.Process.Signal(syscall.SIGTERM); err == nil {
+	if err := r.cmd.Process.Signal(r.config.KillSig); err == nil {
 		// Wait a few seconds for it to exit
 		killCh := make(chan struct{})
 		go func() {

--- a/signals.go
+++ b/signals.go
@@ -15,3 +15,12 @@ var Signals = []os.Signal{
 	syscall.SIGUSR1, // User-defined signal 1
 	syscall.SIGUSR2, // User-defined signal 2
 }
+
+var SignalLookup = map[string]os.Signal {
+	"SIGHUP": syscall.SIGHUP,
+	"SIGINT": syscall.SIGINT,
+	"SIGQUIT": syscall.SIGQUIT,
+	"SIGTERM": syscall.SIGTERM,
+	"SIGUSR1": syscall.SIGUSR1,
+	"SIGUSR2": syscall.SIGUSR2,
+}

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -12,3 +12,9 @@ var Signals = []os.Signal{
 	syscall.SIGTERM,
 	syscall.SIGQUIT,
 }
+
+var SignalLookup = map[string]os.Signal {
+	"SIGINT": syscall.SIGINT,
+	"SIGTERM": syscall.SIGTERM,
+	"SIGQUIT": syscall.SIGQUIT,
+}


### PR DESCRIPTION
I made a quick attempt to fix #45 

Would like some feedback on the approach as far as code consistency and quality. I currently have the same issue as @alexmic with needing to send a `SIGHUP` to gunicorn to reload properly, otherwise things start to fail pretty hard. I have a custom build with the default signal changed to `SIGHUP` for now as a workaround.

The ability to set the signal with this pull request would work by setting `killsig` through the CLI or via a config file and will default to the current default, `SIGTERM`.

Setting it would be `envconsul -killsig SIGHUP` for CLI and `killsig = "SIGHUP"` for the config file.