### PR TITLE
fixing ignored -ssl flag

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -211,6 +211,7 @@ func (cli *CLI) parseFlags(args []string) (*Config, []string, bool, bool, error)
 
 	flags.Var((funcBoolVar)(func(b bool) error {
 		config.SSL.Enabled = b
+		config.set("ssl")
 		config.set("ssl.enabled")
 		return nil
 	}), "ssl", "")


### PR DESCRIPTION
The -ssl command-line flag is skipped because the ssl section was missing.