### PR TITLE
Added "pristine" option 

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -299,6 +299,12 @@ func (cli *CLI) parseFlags(args []string) (*Config, []string, bool, bool, error)
 		return nil
 	}), "log-level", "")
 
+	flags.Var((funcBoolVar)(func(b bool) error {
+		config.Pristine = b
+		config.set("pristine")
+		return nil
+	}), "pristine", "")
+
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&version, "v", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -359,6 +365,9 @@ Options:
 
   -log-level=<level>       Set the logging level - valid values are "debug",
                            "info", "warn" (default), and "err"
+
+  -pristine                Only use variables retrieved from consul, do not inherit
+                           existing environment variables
 
   -once                    Do not run the process as a daemon
   -version                 Print the version of this daemon

--- a/cli_test.go
+++ b/cli_test.go
@@ -452,6 +452,24 @@ func TestParseFlags_version(t *testing.T) {
 	}
 }
 
+func TestParseFlags_pristine(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-pristine",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := true
+	if config.Pristine != expected {
+		t.Errorf("expected %v to be %v", config.Pristine, expected)
+	}
+	if !config.WasSet("pristine") {
+		t.Errorf("expected pristine to be set")
+	}
+}
+
 func TestParseFlags_v(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	_, _, _, version, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -69,6 +69,11 @@ type Config struct {
 	// LogLevel is the level with which to log for this config.
 	LogLevel string `mapstructure:"log_level"`
 
+    // Pristine indicates that we want a clean environment only 
+    // composed of consul config variables, not inheriting from exising
+    // environment
+	Pristine bool `json:"pristine" mapstructure:"pristine"`
+
 	// setKeys is the list of config keys that were set by the user.
 	setKeys map[string]struct{}
 }
@@ -181,6 +186,10 @@ func (c *Config) Merge(config *Config) {
 
 	if config.WasSet("kill_signal") {
 		c.KillSignal = config.KillSignal
+	}
+
+	if config.WasSet("pristine") {
+		c.Pristine = config.Pristine
 	}
 
 	if c.setKeys == nil {
@@ -413,6 +422,7 @@ func DefaultConfig() *Config {
 		Wait:       &watch.Wait{},
 		LogLevel:   logLevel,
 		KillSignal: "SIGTERM",
+        Pristine: false,
 		setKeys:    make(map[string]struct{}),
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -261,9 +261,15 @@ func (r *Runner) Run() (<-chan int, error) {
 	}
 
 	// Create a new environment
-	processEnv := os.Environ()
-	cmdEnv := make([]string, len(processEnv), len(r.env)+len(processEnv))
-	copy(cmdEnv, processEnv)
+    var cmdEnv []string
+
+    if r.config.Pristine {
+	    cmdEnv = make([]string, len(r.env), len(r.env))
+    } else {
+        processEnv := os.Environ()
+	    cmdEnv = make([]string, len(processEnv), len(r.env)+len(processEnv))
+	    copy(cmdEnv, processEnv)
+    }
 	for k, v := range r.env {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("%s=%s", k, v))
 	}


### PR DESCRIPTION
Added a "pristine" option such that the environment generated does not inherit from the existing shell environment.  The only values that are put into the environment are those from the consul service.