### PR TITLE
Fix for extra newlines noted in issue #59

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -262,10 +262,8 @@ func (r *Runner) Run() (<-chan int, error) {
 
 	// Create a new environment
 	var cmdEnv []string
-
-	if r.config.Pristine {
-		cmdEnv = make([]string, len(r.env), len(r.env))
-	} else {
+	
+	if ! r.config.Pristine {
 		processEnv := os.Environ()
 		cmdEnv = make([]string, len(processEnv), len(r.env)+len(processEnv))
 		copy(cmdEnv, processEnv)


### PR DESCRIPTION
When using the -pristine option, a call is being made to make() and returned to cmdEnv. This isn't needed for a string type (cmdEnv is declared as a string on line 264). The call to make() creates a slice padded with whitespace equal to the length of r.env. When cmdEnv is later appended to with the actual key/values from consul, these key/values are added to the end of this slice, leaving the padded whitespace in place which leads to multiple empty lines equal to r.env. The call to make() is needed when -pristine is not being used because of the subsequent call to copy().