### PR TITLE
Prepend environment option

### DIFF
--- a/config.go
+++ b/config.go
@@ -64,6 +64,9 @@ type Config struct {
 	// Sanitize converts any "bad" characters in key values to underscores
 	Sanitize bool `json:"sanitize" mapstructure:"sanitize"`
 
+	// Prepend envconsul values to the environment rather than appending it
+	Prepend bool `json:"prepend" mapstructure:"prepend"`
+
 	// Splay is the maximum time in seconds to wait before restarting the program,
 	// from which a random value is chosen. This is designed to prevent the
 	// "thundering herd" problem.
@@ -255,7 +258,12 @@ func (c *Config) Merge(config *Config) {
 	if config.WasSet("pristine") {
 		c.Pristine = config.Pristine
 	}
+	
+	if config.WasSet("prepend") {
+		c.Prepend = config.Prepend
+	}
 
+	
 	if c.setKeys == nil {
 		c.setKeys = make(map[string]struct{})
 	}
@@ -465,6 +473,7 @@ func DefaultConfig() *Config {
 		LogLevel:   logLevel,
 		KillSignal: "SIGTERM",
 		Pristine:   false,
+		Prepend:    false, 
 		setKeys:    make(map[string]struct{}),
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -278,10 +278,17 @@ func (r *Runner) Run() (<-chan int, error) {
 	} else {
 		processEnv := os.Environ()
 		cmdEnv = make([]string, len(processEnv), len(r.env)+len(processEnv))
-		copy(cmdEnv, processEnv)
+		if !r.config.Prepend {
+			copy(cmdEnv, processEnv)
+		}
 	}
 	for k, v := range r.env {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("%s=%s", k, v))
+	}
+	if r.config.Prepend {
+		for _, env := range os.Environ() {
+			cmdEnv = append(cmdEnv, env)
+		}
 	}
 
 	// Create the command


### PR DESCRIPTION
After some debugging I just learned that "java" has an interesting way to get the environment into the java world 

```
        // Read environment variables back to front,
        // so that earlier variables override later ones.
```
that is a quote from java.lang.ProcessEnvironment.

I'd rather have it the other way around, as envconsul does it that way. But anyway, I added a "prepend" config option to actually prepend envconsules environment before the original environment.

I actually don't speak go, but some guesswork later it works as I want it. Any comments?
