### PR TITLE
Load VAULT_TOKEN from the environment into config

### DIFF
--- a/config.go
+++ b/config.go
@@ -480,6 +480,10 @@ func DefaultConfig() *Config {
 		config.Vault.Address = v
 	}
 
+	if v := os.Getenv("VAULT_TOKEN"); v != "" {
+		config.Vault.Token = v
+	}
+
 	if v := os.Getenv("VAULT_CAPATH"); v != "" {
 		config.Vault.SSL.Cert = v
 	}


### PR DESCRIPTION
This fixes an issue with Vault tokens not being renewed automatically
unless they are hardcoded in configuration. This commit makes it
possible for tokens set via `VAULT_TOKEN` in the environment to also be
renewed automatically when `renew` is configured.

Resolves https://github.com/hashicorp/envconsul/issues/99 and related to https://github.com/hashicorp/consul-template/commit/2431448c7edd50fd2a2165f4a709f0bb1736e0a3