### PR TITLE
Add the ability to opt out of path prefixing for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ secret/passwords     => secret_passwords
 mysql/creds/readonly => mysql_creds_readonly
 ```
 
+This behavior may be disabled by setting `no_prefix`
+
+```javascript
+secret {
+  no_prefix = true
+  path   = "secret/passwords"
+}
+
+username=foo
+password=bar
+```
+
 You can also apply key transformations to the data:
 
 ```

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ secret {
 }
 ```
 
-The format string is passed to the go formatter and "%s" dictates where the key will go. This will help filter out the environment when execing to a child-process, for example.
+The format string is passed to the go formatter and "{{ key }}" dictates where the key will go. This will help filter out the environment when execing to a child-process, for example.
 
 Debugging
 ---------

--- a/config.go
+++ b/config.go
@@ -510,8 +510,9 @@ func DefaultConfig() *Config {
 // ConfigPrefix is a wrapper around some common options for Consul and Vault
 // prefixes.
 type ConfigPrefix struct {
-	Path   string `json:"path" mapstructure:"path"`
-	Format string `json:"format" mapstructure:"format"`
+	Path     string `json:"path" mapstructure:"path"`
+	Format   string `json:"format" mapstructure:"format"`
+	NoPrefix bool   `json:"no_prefix" mapstructure:"no_prefix"`
 }
 
 // AuthConfig is the HTTP basic authentication data.

--- a/config_test.go
+++ b/config_test.go
@@ -295,6 +295,12 @@ func TestParseConfig_correctValues(t *testing.T) {
 			path = "secret/redis"
 		}
 
+		secret {
+			no_prefix = true
+			path = "secret/redis"
+			format = "no_prefix_{{ key }}"
+		}
+
 		auth {
 			enabled = true
 			username = "test"
@@ -379,6 +385,7 @@ func TestParseConfig_correctValues(t *testing.T) {
 		},
 		Secrets: []*ConfigPrefix{
 			&ConfigPrefix{Path: "secret/redis"},
+			&ConfigPrefix{Path: "secret/redis", Format: "no_prefix_{{ key }}", NoPrefix: true},
 		},
 		setKeys: config.setKeys,
 	}

--- a/runner.go
+++ b/runner.go
@@ -422,11 +422,13 @@ func (r *Runner) appendSecrets(
 			continue
 		}
 
-		// Replace the path slashes with an underscore.
-		path := InvalidRegexp.ReplaceAllString(d.Path, "_")
+		if !cp.NoPrefix {
+			// Replace the path slashes with an underscore.
+			path := InvalidRegexp.ReplaceAllString(d.Path, "_")
 
-		// Prefix the key value with the path value.
-		key = fmt.Sprintf("%s_%s", path, key)
+			// Prefix the key value with the path value.
+			key = fmt.Sprintf("%s_%s", path, key)
+		}
 
 		// If the user specified a custom format, apply that here.
 		if cp.Format != "" {


### PR DESCRIPTION
If I have a single vault with secrets for many staging/development environments I would have to alter my application to prefix its settings with the environment name.
This change allows user to use the same deployment script for each of those environments, save changing the secret's path.

``` javascript
secret {
    path = 'application_name/staging-01'
}
```

``` python
MY_SETTING = os.environ['APPLICATION_NAME_%s_MY_SETTING' % os.environ.get('ENVIRONMENT', '')]
```

becomes

``` javascript
secret {
    no_prefix = true
    path = 'application_name/staging-01'
}
```

``` python
MY_SETTING = os.environ['MY_SETTING']
```
