### PR TITLE
Check is returned value is nil

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -422,6 +422,11 @@ func (r *Runner) appendSecrets(
 			continue
 		}
 
+		// Ignore any keys in which value is nil
+		if value == nil {
+			continue
+		}
+
 		// Replace the path slashes with an underscore.
 		path := InvalidRegexp.ReplaceAllString(d.Path, "_")
 


### PR DESCRIPTION
If vault returns a null value for a key, envconsul will break with the following error:
```
panic: interface conversion: interface is nil, not string

goroutine 7 [running]:
panic(0x8bd840, 0xc820329080)
	/usr/lib/go-1.6/src/runtime/panic.go:481 +0x3e6
main.(*Runner).appendSecrets(0xc8200da000, 0xc82040d800, 0xc8200de6f0, 0x7c5da0, 0xc82040d710, 0x0, 0x0)
	/root/go/src/github.com/hashicorp/envconsul/runner.go:454 +0xc03
main.(*Runner).Run(0xc8200da000, 0x0, 0x0, 0x0)
	/root/go/src/github.com/hashicorp/envconsul/runner.go:254 +0x12db
main.(*Runner).Start(0xc8200da000)
	/root/go/src/github.com/hashicorp/envconsul/runner.go:172 +0x455
created by main.(*CLI).Run
	/root/go/src/github.com/hashicorp/envconsul/cli.go:102 +0x539
```


this issue can be easily reproduced by using the AWS credentials backend in vault and attempting retrieve a set of keys from the /creds/ endpoint, which returns null value for the _security_token_ key.

Relevant debug log:
```
2017/01/09 18:02:25 [DEBUG] (runner) setting AWSTEST_CREDS_POWER_USER_ACCESS_KEY="<redacted>" from "secret(awstest/creds/power-user)"
2017/01/09 18:02:25 [DEBUG] (runner) setting AWSTEST_CREDS_POWER_USER_SECRET_KEY="<redacted>" from "secret(awstest/creds/power-user)"
2017/01/09 18:02:25 [DEBUG] (runner) setting AWSTEST_CREDS_POWER_USER_SECURITY_TOKEN=%!q(<nil>) from "secret(awstest/creds/power-user)"
```