### PR TITLE
CLI option for secret without vault path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage
 | `retry`           | The amount of time to wait if Consul returns an error when communicating with the API. The default value is 5 seconds.
 | `prefix`          | A prefix to watch in Consul. This may be specified multiple times.
 | `secret`          | A secret to watch in Vault. This may be specified multiple times.
+| `secret-no-prefix`| Same like `-secret` but doesn't prefix the environment variable name with the path.
 | `sanitize`        | Replace invalid characters in keys to underscores.
 | `splay`           | The maximum time to wait before restarting the program, from which a random value is chosen.
 | `upcase`          | Convert all environment variable keys to uppercase.

--- a/cli.go
+++ b/cli.go
@@ -213,6 +213,18 @@ func (cli *CLI) parseFlags(args []string) (*Config, []string, bool, bool, error)
 	}), "secret", "")
 
 	flags.Var((funcVar)(func(s string) error {
+		s = strings.TrimPrefix(s, "/")
+		if config.Secrets == nil {
+			config.Secrets = make([]*ConfigPrefix, 0, 1)
+		}
+		config.Secrets = append(config.Secrets, &ConfigPrefix{
+			Path:     s,
+			NoPrefix: true,
+		})
+		return nil
+	}), "secret-no-prefix", "")
+
+	flags.Var((funcVar)(func(s string) error {
 		config.Auth.Enabled = true
 		config.set("auth.enabled")
 		if strings.Contains(s, ":") {
@@ -425,6 +437,8 @@ Options:
                                are merged from left to right, with the right-most
                                result taking precedence, including any values
                                specified with -prefix
+  -secret-no-prefix=<prefix>   Same like -secret but doesn't prefix the environment
+                               variable name with the path
 
   -sanitize                    Replace invalid characters in keys to underscores
   -upcase                      Convert all environment variable keys to uppercase

--- a/cli_test.go
+++ b/cli_test.go
@@ -77,6 +77,21 @@ func TestParseFlags_secret(t *testing.T) {
 	}
 }
 
+func TestParseFlags_secret_no_prefix(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-secret-no-prefix", "global",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &ConfigPrefix{Path: "global", NoPrefix: true}
+	if !reflect.DeepEqual(config.Secrets[0], expected) {
+		t.Errorf("expected %#v to be %#v", config.Secrets[0], expected)
+	}
+}
+
 func TestParseFlags_authUsername(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	config, _, _, _, err := cli.parseFlags([]string{


### PR DESCRIPTION
Based on #113 but also adds CLI option