### PR TITLE
Add an env-prefix to add a prefix to each env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Usage
 | `upcase`          | Convert all environment variable keys to uppercase.
 | `config`          | The path to a configuration file or directory of configuration files on disk, relative to the current working directory. Values specified on the CLI take precedence over values specified in the configuration file. There is no default value.
 | `log-level`       | The log level for output. This applies to the stdout/stderr logging as well as syslog logging (if enabled). Valid values are "debug", "info", "warn", and "err". The default value is "warn".
-| `pristine`       | Only use variables retrieved from consul, do not inherit existing environment variables.
+| `pristine`        | Only use variables retrieved from consul, do not inherit existing environment variables.
+| `env-prefix`      | Add a prefix to each variable set in the environment. The default value is "".
 | `once`            | Run envconsul once and exit (as opposed to the default behavior of daemon). _(CLI-only)_
 | `version`         | Output version information and quit. _(CLI-only)_
 

--- a/cli.go
+++ b/cli.go
@@ -336,6 +336,12 @@ func (cli *CLI) parseFlags(args []string) (*Config, []string, bool, bool, error)
 		return nil
 	}), "pristine", "")
 
+	flags.Var((funcVar)(func(s string) error {
+		config.EnvPrefix = s
+		config.set("env_prefix")
+		return nil
+	}), "env-prefix", "")
+
 	flags.BoolVar(&once, "once", false, "")
 	flags.BoolVar(&version, "v", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -430,6 +436,9 @@ Options:
   -upcase                      Convert all environment variable keys to uppercase
   -pristine                    Only use variables retrieved from Consul, do not
                                inherit existing environment variables
+
+  -env-prefix=<prefix>		   Adds the provided prefix to variables added to the
+  							   environment.
 
   -kill-signal=<signal>        The signal to send to kill the process. Defaults to
                                SIGTERM

--- a/cli_test.go
+++ b/cli_test.go
@@ -518,6 +518,24 @@ func TestParseFlags_pristine(t *testing.T) {
 	}
 }
 
+func TestParseFlags_env_prefix(t *testing.T) {
+	cli := NewCLI(ioutil.Discard, ioutil.Discard)
+	config, _, _, _, err := cli.parseFlags([]string{
+		"-env-prefix", "TEST_",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "TEST_"
+	if config.EnvPrefix != expected {
+		t.Errorf("expected %v to be %v", config.EnvPrefix, expected)
+	}
+	if !config.WasSet("env_prefix") {
+		t.Errorf("expected env_prefix to be set")
+	}
+}
+
 func TestParseFlags_v(t *testing.T) {
 	cli := NewCLI(ioutil.Discard, ioutil.Discard)
 	_, _, _, version, err := cli.parseFlags([]string{

--- a/config.go
+++ b/config.go
@@ -85,6 +85,10 @@ type Config struct {
 	// environment
 	Pristine bool `json:"pristine" mapstructure:"pristine"`
 
+	// EnvPrefix is an optional prefix which will be added to each
+	// variable set in the environment.
+	EnvPrefix string `json:"env_prefix" mapstructure:"env_prefix"`
+
 	// setKeys is the list of config keys that were set by the user.
 	setKeys map[string]struct{}
 }
@@ -257,6 +261,10 @@ func (c *Config) Merge(config *Config) {
 
 	if config.WasSet("pristine") {
 		c.Pristine = config.Pristine
+	}
+
+	if config.WasSet("env_prefix") {
+		c.EnvPrefix = config.EnvPrefix
 	}
 
 	if c.setKeys == nil {
@@ -453,6 +461,7 @@ func DefaultConfig() *Config {
 		LogLevel:   logLevel,
 		KillSignal: "SIGTERM",
 		Pristine:   false,
+		EnvPrefix:  "",
 		setKeys:    make(map[string]struct{}),
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -399,6 +399,15 @@ func (r *Runner) appendPrefixes(
 			key = strings.ToUpper(key)
 		}
 
+		// This is intentionally done after sanitization and upcasing because
+		// a user can provide a sanitized and upcased env prefix if they want one
+		// at the same time they configure the other options.  This way, though,
+		// they can also have a lower case or unsanitized prefix if they actually
+		// want it that way.
+		if r.config.EnvPrefix != "" {
+			key = r.config.EnvPrefix + key
+		}
+
 		if current, ok := env[key]; ok {
 			log.Printf("[DEBUG] (runner) overwriting %s=%q (was %q) from %s",
 				key, value, current, d.Display())


### PR DESCRIPTION
This adds an env-prefix (or env_prefix in the config) option to automatically add a prefix to any variables pulled from Consul and put in the environment.  I saw #121 asked for this feature and it's something I need as well, so why not PR it? :) 