### PR TITLE
make splay more random

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -559,6 +559,7 @@ func (r *Runner) killProcess() {
 	// If a splay value was given, sleep for a random amount of time up to the
 	// splay.
 	if r.config.Splay > 0 {
+		rand.Seed(time.Now().UnixNano())
 		nanoseconds := r.config.Splay.Nanoseconds()
 		offset := rand.Int63n(nanoseconds)
 

--- a/runner.go
+++ b/runner.go
@@ -546,6 +546,10 @@ func (r *Runner) init() error {
 		r.configPrefixMap[d.HashCode()] = s
 	}
 
+	// Seed the default rand Source with current time to produce better random
+	// numbers used with splay
+	rand.Seed(time.Now().UnixNano())
+	
 	return nil
 }
 
@@ -559,7 +563,6 @@ func (r *Runner) killProcess() {
 	// If a splay value was given, sleep for a random amount of time up to the
 	// splay.
 	if r.config.Splay > 0 {
-		rand.Seed(time.Now().UnixNano())
 		nanoseconds := r.config.Splay.Nanoseconds()
 		offset := rand.Int63n(nanoseconds)
 


### PR DESCRIPTION
Using the default *rand* source produces a deterministic sequence of values each time `envconsul` is run. This causes issues when running multiple docker instances, for example, because `rand.Int63n(nanoseconds)` returns the same value.