### PR TITLE
Add log message for forceful child terminations

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -549,9 +549,9 @@ func (r *Runner) init() error {
 	return nil
 }
 
-// Restart the current process in the Runner by sending a SIGTERM. It is
-// assumed that the process is set on the Runner! It is the caller's
-// responsibility to lock the runner.
+// Kill the current process in the Runner by sending the r.killSignal and, if
+// necessary, SIGKILL. It is assumed that the process is set on the Runner! It
+// is the caller's responsibility to lock the runner.
 func (r *Runner) killProcess() {
 	// Kill the process
 	exited := false
@@ -586,8 +586,10 @@ func (r *Runner) killProcess() {
 		}
 	}
 
-	// If we still haven't exited from a SIGKILL
+	// If the process still hasn't exited
 	if !exited {
+		log.Printf("[INFO] (runner) command did not exit within %v; killing forcefully",
+			r.config.Timeout)
 		r.cmd.Process.Kill()
 	}
 


### PR DESCRIPTION
consulenv should not send SIGKILL silently. 

I was contemplating making this a warning so it shows up by default, but this level seems to be intended for things that consulenv itself doesn't expect. Let me know if you disagree and I will happily change it to a warning.