### PR TITLE
Exit when there are no dependencies to get env variables from

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -105,6 +105,11 @@ func NewRunner(config *Config, once bool) (*Runner, error) {
 func (r *Runner) Start() {
 	log.Printf("[INFO] (runner) starting")
 
+	if len(r.dependencies) == 0 {
+		r.ErrCh <- errors.New("No dependencies to get variables from")
+		return
+	}
+
 	// Add each dependency to the watcher
 	for _, d := range r.dependencies {
 		r.watcher.Add(d)


### PR DESCRIPTION
I tried envconsul for first time

```
envconsul env
```

And it stuck. 

* I found  (it was not obvious) that you need prefix to get variables from consul.  
* What is worse - it does not exit with error, it is just stuck. 

With following solution it will exit with error immediately. WDYT?
