### PR TITLE
Added -env-prefix option to prepend the keys returned from envconsul

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -375,6 +375,11 @@ func (cli *CLI) ParseFlags(args []string) (*Config, []string, bool, bool, error)
 	}), "pid-file", "")
 
 	flags.Var((funcVar)(func(s string) error {
+		c.EnvPrefix = config.String(s)
+		return nil
+	}), "env-prefix", "")
+
+	flags.Var((funcVar)(func(s string) error {
 		p, err := ParsePrefixConfig(s)
 		if err != nil {
 			return err
@@ -740,6 +745,10 @@ Options:
 
   -consul-transport-tls-handshake-timeout=<duration>
       Sets the handshake timeout
+
+  -env-prefix=<prefix>
+      Sets a prefix to be added to environment variables keys prior to any key
+      modifications by -sanitize and -upcase
 
   -exec=<command>
       Enable exec mode to run as a supervisor-like process - the given command

--- a/cli_test.go
+++ b/cli_test.go
@@ -432,6 +432,14 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"env-prefix",
+			[]string{"-env-prefix", "testprefix_"},
+			&Config{
+				EnvPrefix: config.String("testprefix_"),
+			},
+			false,
+		},
+		{
 			"exec",
 			[]string{"-exec", "command"},
 			&Config{

--- a/config.go
+++ b/config.go
@@ -55,6 +55,9 @@ type Config struct {
 	// this processes PID.
 	PidFile *string `mapstructure:"pid_file"`
 
+	// EnvPrefix is a prefix added to the keys returned from consul
+	EnvPrefix *string `mapstructure:"env_prefix"`
+
 	// Prefixes is the list of all prefix dependencies (consul)
 	// in merge order.
 	Prefixes *PrefixConfigs `mapstructure:"prefix"`
@@ -106,6 +109,8 @@ func (c *Config) Copy() *Config {
 	o.MaxStale = c.MaxStale
 
 	o.PidFile = c.PidFile
+
+	o.EnvPrefix = c.EnvPrefix
 
 	o.ReloadSignal = c.ReloadSignal
 
@@ -174,6 +179,10 @@ func (c *Config) Merge(o *Config) *Config {
 
 	if o.PidFile != nil {
 		r.PidFile = o.PidFile
+	}
+
+	if o.EnvPrefix != nil {
+		r.EnvPrefix = o.EnvPrefix
 	}
 
 	if o.ReloadSignal != nil {
@@ -491,6 +500,7 @@ func (c *Config) GoString() string {
 		"LogLevel:%s, "+
 		"MaxStale:%s, "+
 		"PidFile:%s, "+
+		"EnvPrefix:%s, "+
 		"Prefixes:%s, "+
 		"Pristine:%s, "+
 		"ReloadSignal:%s, "+
@@ -507,6 +517,7 @@ func (c *Config) GoString() string {
 		config.StringGoString(c.LogLevel),
 		config.TimeDurationGoString(c.MaxStale),
 		config.StringGoString(c.PidFile),
+		config.StringGoString(c.EnvPrefix),
 		c.Prefixes.GoString(),
 		config.BoolGoString(c.Pristine),
 		config.SignalGoString(c.ReloadSignal),
@@ -571,6 +582,10 @@ func (c *Config) Finalize() {
 
 	if c.PidFile == nil {
 		c.PidFile = config.String("")
+	}
+
+	if c.EnvPrefix == nil {
+		c.EnvPrefix = config.String("")
 	}
 
 	if c.Pristine == nil {

--- a/config_test.go
+++ b/config_test.go
@@ -578,6 +578,14 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"env_prefix",
+			`env_prefix = "hello"`,
+			&Config{
+				EnvPrefix: config.String("hello"),
+			},
+			false,
+		},
+		{
 			"exec_timeout",
 			`exec {
 				timeout = "30s"
@@ -1272,6 +1280,18 @@ func TestConfig_Merge(t *testing.T) {
 				Consul: &config.ConsulConfig{
 					Address: config.String("consul-diff"),
 				},
+			},
+		},
+		{
+			"env_prefix",
+			&Config{
+				EnvPrefix: config.String("env_prefix"),
+			},
+			&Config{
+				EnvPrefix: config.String("env_prefix-diff"),
+			},
+			&Config{
+				EnvPrefix: config.String("env_prefix-diff"),
 			},
 		},
 		{

--- a/runner.go
+++ b/runner.go
@@ -382,6 +382,10 @@ func (r *Runner) appendPrefixes(
 			}
 		}
 
+		if config.StringVal(r.config.EnvPrefix) != "" {
+			key = fmt.Sprint(config.StringVal(r.config.EnvPrefix), key)
+		}
+
 		if config.BoolVal(r.config.Sanitize) {
 			key = InvalidRegexp.ReplaceAllString(key, "_")
 		}
@@ -445,6 +449,10 @@ func (r *Runner) appendSecrets(
 			if err != nil {
 				return err
 			}
+		}
+
+		if config.StringVal(r.config.EnvPrefix) != "" {
+			key = fmt.Sprint(config.StringVal(r.config.EnvPrefix), key)
 		}
 
 		if config.BoolVal(r.config.Sanitize) {


### PR DESCRIPTION
This code was somewhat borrowed from https://github.com/chrisriley/envconsul/commit/c9d050614606c13c3e2872891b04658add267160