### PR TITLE
Allow passing a prefix format along with prefix path

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -774,10 +774,13 @@ Options:
   -pid-file=<path>
       Path on disk to write the PID of the process
 
-  -prefix=<prefix>
+  -prefix=<prefix path>[@<prefix format>]
       A prefix to watch, multiple prefixes are merged from left to right, with
       the right-most result taking precedence, including any values specified
       with -secret
+      Optionally, a prefix format can be passed along with the path. The
+      delimiter in use is "@".  By default, an empty format defaults on "{{ key }}",
+      each prefix can have its own format.
 
   -pristine
       Only use values retrieved from prefixes and secrets, do not inherit the

--- a/cli_test.go
+++ b/cli_test.go
@@ -520,7 +520,7 @@ func TestCLI_ParseFlags(t *testing.T) {
 			"prefix_multi",
 			[]string{
 				"-prefix", "foo/bar",
-				"-prefix", "zip/zap",
+				"-prefix", "zip/zap@zap_{{key}}",
 			},
 			&Config{
 				Prefixes: &PrefixConfigs{
@@ -529,6 +529,7 @@ func TestCLI_ParseFlags(t *testing.T) {
 					},
 					&PrefixConfig{
 						Path: config.String("zip/zap"),
+						Format: config.String("zap_{{key}}"),
 					},
 				},
 			},

--- a/config_prefix.go
+++ b/config_prefix.go
@@ -16,10 +16,24 @@ type PrefixConfig struct {
 }
 
 func ParsePrefixConfig(s string) (*PrefixConfig, error) {
-	s = strings.TrimPrefix(s, "/")
-	return &PrefixConfig{
-		Path: config.String(s),
-	}, nil
+	switch parts := strings.Split(s, "@"); len(parts) {
+	case 1:
+		path := strings.TrimPrefix(parts[0], "/")
+
+		return &PrefixConfig{
+			Path: config.String(path),
+		}, nil
+	case 2:
+		path := strings.TrimPrefix(parts[0], "/")
+		format := parts[1]
+
+		return &PrefixConfig{
+			Path: config.String(path),
+			Format: config.String(format),
+		}, nil
+	default:
+		return nil, fmt.Errorf("Wrong number of delimiters found when parsing prefix (%d, expected 1 at most)", len(parts))
+	}
 }
 
 func DefaultPrefixConfig() *PrefixConfig {


### PR DESCRIPTION
This commit makes it possible to pass a prefix format to the CLI, along
with a prefix path, also enabling one format per path.

The delimiter that has been chosen is "@", as this character is not
allowed in the naming scheme of environment variables [1].

This type of command is now possible:

    envconsul -prefix my_prefix_1@pref1_{{key}} -prefix my_prefix_2@some_other_prefix_{{key}}

[1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html