### PR TITLE
rough implementation of the env_exec settings

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -301,14 +301,11 @@ func (r *Runner) Run() (<-chan int, error) {
 	// anyGlobMatch is a helper function which checks if any of the given globs
 	// match the string.
 	anyGlobMatch := func(s string, patterns []string) bool {
-		fmt.Printf("comparing\n %s with %s", s, patterns)
 		for _, pattern := range patterns {
 			if matched, _ := filepath.Match(pattern, s); matched {
-				fmt.Printf("match\n")
 				return true
 			}
 		}
-		fmt.Printf("no match\n")
 		return false
 	}
 


### PR DESCRIPTION
it looks like the following settings were silently "removed" when `consul-template` apis were factored in to `envconsul`:

- `exec_env_pristine`
- `exec_env_custom`
- `exec_env_whitelist`
- `exec_env_blacklist`

This PR is a **rough** restoration of the functionality. Feedback desperately desired.

re #155 