### PR TITLE
Allow users to use ENV vars in prefix paths using Go templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,13 @@ prefix {
   path = "foo/bar"
 }
 
+prefix {
+  # This tells Envconsul to use a custom formatter when building the path for
+  # the key from which to read data, in this case reading an environment
+  # variable and putting it into the path.
+  path = "foo/{{ env \"BAR\" }}"
+}
+
 # This tells Envconsul to not include the parent processes' environment when
 # launching the child process.
 pristine = false

--- a/README.md
+++ b/README.md
@@ -345,9 +345,7 @@ prefix {
 
   # This is the path of the key in Consul or Vault from which to read data.
   path = "foo/bar"
-}
 
-prefix {
   # This tells Envconsul to use a custom formatter when building the path for
   # the key from which to read data, in this case reading an environment
   # variable and putting it into the path.

--- a/config_test.go
+++ b/config_test.go
@@ -686,6 +686,20 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"prefix_path_template",
+			`prefix {
+				path = "foo/{{ env \"BAR\" }}"
+			}`,
+			&Config{
+				Prefixes: &PrefixConfigs{
+					&PrefixConfig{
+						Path: config.String(`foo/{{ env "BAR" }}`),
+					},
+				},
+			},
+			false,
+		},
+		{
 			"pristine",
 			`pristine = true`,
 			&Config{

--- a/runner.go
+++ b/runner.go
@@ -335,7 +335,7 @@ func (r *Runner) Run() (<-chan int, error) {
 	return child.ExitCh(), nil
 }
 
-func applyTemplate(contents, key string) (string, error) {
+func applyFormatTemplate(contents, key string) (string, error) {
 	funcs := template.FuncMap{
 		"key": func() (string, error) {
 			return key, nil
@@ -380,7 +380,7 @@ func (r *Runner) appendPrefixes(
 
 		// If the user specified a custom format, apply that here.
 		if config.StringPresent(cp.Format) {
-			key, err = applyTemplate(config.StringVal(cp.Format), key)
+			key, err = applyFormatTemplate(config.StringVal(cp.Format), key)
 			if err != nil {
 				return err
 			}
@@ -482,7 +482,7 @@ func (r *Runner) appendSecrets(
 
 		// If the user specified a custom format, apply that here.
 		if config.StringPresent(cp.Format) {
-			key, err = applyTemplate(config.StringVal(cp.Format), key)
+			key, err = applyFormatTemplate(config.StringVal(cp.Format), key)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

This PR adds the ability to use Go templates in prefix paths, and use environment variables in these templates.

## Background

For the application our team works on, we have the same binary which can start up in different roles, eg. "background-worker" or "api-server". We have a mix of global (per-environment) config, and some role specific config, all of which is currently in Consul.

We'd love to be able to use `envconsul` without needing to render a separate config file per role using configuration management, and instead being able to provide a template to build the Consul/Vault key prefix. We'd also like to make use of the "shadowing" ability by using multiple `prefix` stanzas in the configuration, allowing us to retain the ability to set custom key formatters which is unavailable in the CLI.

We can of course approximate this by using multiple config files via the CLI, but this felt like a nicer way to go as we had less to manage in on our hosts.

## Example

Set up some state in Consul

```sh
# shared or default config
consul kv put config/shared/log-level INFO

# role specific config
consul kv put config/api-server/port 8080
consul kv put config/background-worker/log-level DEBUG
```

Create configuration file for envconsul

```hcl
# envconsul.hcl

pristine = true

sanitize = true

upcase = true

# shared configuration
prefix {
  path = "config/shared"
}

# role-specific configuration
prefix {
  path = "config/{{ env \"ROLE\"}}"
}

```

#### Output

```sh
# using config file
$ ROLE=api-server envconsul -config envconsul.hcl env
LOG_LEVEL=INFO
PORT=8080

$ ROLE=background-worker envconsul -config envconsul.hcl env
LOG_LEVEL=DEBUG

# or the CLI, although this isn't strictly necessary as you could just use the ENV var inline
$ ROLE=api-server envconsul -upcase -pristine -prefix=config/shared -prefix='config/{{ env "ROLE" }}' env
PORT=8080
LOG-LEVEL=INFO

$ ROLE=background-worker envconsul -upcase -pristine -prefix=config/shared -prefix='config/{{ env "ROLE" }}' env
LOG-LEVEL=DEBUG
```

