### PR TITLE
Added "looking at vault" to INFO log level

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -524,7 +524,7 @@ func (r *Runner) init() error {
 	// typically less controlled than access to vault.
 	for _, s := range *r.config.Secrets {
 		path := config.StringVal(s.Path)
-		log.Printf("looking at vault %s", path)
+		log.Printf("[INFO] looking at vault %s", path)
 		d, err := dep.NewVaultReadQuery(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
We needed a way to start envconsul with no output and couldn't find a way to squelch the 'looking at vault...' output.

This pull request moves that output to the INFO log level output.