### PR TITLE
Respect exec.env config block

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -754,8 +754,7 @@ func (r *Runner) applyConfigEnv(env map[string]string) map[string]string {
 	}
 
 	// Filter to envvars that match the whitelist
-	n := len(r.config.Exec.Env.Whitelist)
-	if n > 0 {
+	if n := len(r.config.Exec.Env.Whitelist); n > 0 {
 		include := make(map[string]bool, n)
 		for k, _ := range keys {
 			if anyGlobMatch(k, r.config.Exec.Env.Whitelist) {

--- a/runner.go
+++ b/runner.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -231,12 +232,6 @@ func (r *Runner) Run() (<-chan int, error) {
 
 	env := make(map[string]string)
 
-	// Store custom env variables from config
-	for _, v := range r.config.Exec.Env.Custom {
-		list := strings.SplitN(v, "=", 2)
-		env[list[0]] = list[1]
-	}
-
 	// Iterate over each dependency and pull out its data. If any dependencies do
 	// not have data yet, this function will immediately return because we cannot
 	// safely continue until all dependencies have received data at least once.
@@ -300,12 +295,14 @@ func (r *Runner) Run() (<-chan int, error) {
 		newEnv[k] = v
 	}
 
+	filteredEnv := r.applyConfigEnv(newEnv)
+
 	// Prepare the final environment. Note that it's CRUCIAL for us to
 	// initialize this slice to an empty one vs. a nil one, since that's
 	// how the child process class decides whether to pull in the parent's
 	// environment or not, and we control that via -pristine.
 	cmdEnv := make([]string, 0)
-	for k, v := range newEnv {
+	for k, v := range filteredEnv {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("%s=%s", k, v))
 	}
 
@@ -718,4 +715,78 @@ func newWatcher(c *Config, clients *dep.ClientSet, once bool) (*watch.Watcher, e
 		return nil, errors.Wrap(err, "runner")
 	}
 	return w, nil
+}
+
+// applyConfigEnv applies custom env variables and whitelist/blacklist rules from config
+func (r *Runner) applyConfigEnv(env map[string]string) map[string]string {
+	// Parse custom environment variables
+	custom := make(map[string]string, len(r.config.Exec.Env.Custom))
+	for _, v := range r.config.Exec.Env.Custom {
+		list := strings.SplitN(v, "=", 2)
+		custom[list[0]] = list[1]
+	}
+
+	// In pristine mode, just return the custom environment. If the user did not
+	// specify a custom environment, just return the empty slice to force an
+	// empty environment. We cannot return nil here because the later call to
+	// os/exec will think we want to inherit the parent.
+	if config.BoolVal(r.config.Exec.Env.Pristine) {
+		if len(custom) > 0 {
+			return custom
+		}
+		return make(map[string]string)
+	}
+
+	keys := make(map[string]bool, len(env))
+	for k, _ := range env {
+		keys[k] = true
+	}
+
+	// anyGlobMatch is a helper function which checks if any of the given globs
+	// match the string.
+	anyGlobMatch := func(s string, patterns []string) bool {
+		for _, pattern := range patterns {
+			if matched, _ := filepath.Match(pattern, s); matched {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Filter to envvars that match the whitelist
+	n := len(r.config.Exec.Env.Whitelist)
+	if n > 0 {
+		include := make(map[string]bool, n)
+		for k, _ := range keys {
+			if anyGlobMatch(k, r.config.Exec.Env.Whitelist) {
+				include[k] = true
+			}
+		}
+		keys = include
+	}
+
+	// Remove any env vars that match the blacklist
+	// Blacklist takes precedence over whitelist
+	if len(r.config.Exec.Env.Blacklist) > 0 {
+		for k, _ := range keys {
+			if anyGlobMatch(k, r.config.Exec.Env.Blacklist) {
+				delete(keys, k)
+			}
+		}
+	}
+
+	// Filter env to allowed keys
+	for k, _ := range env {
+		if _, ok := keys[k]; !ok {
+			delete(env, k)
+		}
+	}
+
+	// Add custom env to final map
+	// Custom variables take precedence over whitelist and blacklist
+	for k, v := range custom {
+		env[k] = v
+	}
+
+	return env
 }

--- a/runner.go
+++ b/runner.go
@@ -231,6 +231,12 @@ func (r *Runner) Run() (<-chan int, error) {
 
 	env := make(map[string]string)
 
+	// Store custom env variables from config
+	for _, v := range r.config.Exec.Env.Custom {
+		list := strings.SplitN(v, "=", 2)
+		env[list[0]] = list[1]
+	}
+
 	// Iterate over each dependency and pull out its data. If any dependencies do
 	// not have data yet, this function will immediately return because we cannot
 	// safely continue until all dependencies have received data at least once.

--- a/runner_test.go
+++ b/runner_test.go
@@ -61,7 +61,8 @@ func TestRunner_appendSecrets(t *testing.T) {
 			},
 			true,
 		},
-		"int_secret_skipped": {
+		{
+			"int_secret_skipped",
 			"kv/foo",
 			&dependency.Secret{
 				Data: map[string]interface{}{

--- a/runner_test.go
+++ b/runner_test.go
@@ -121,46 +121,40 @@ func TestRunner_configEnv(t *testing.T) {
 		blacklist []string
 		output    map[string]string
 	}{
-		// pristine env with no custom vars leads to empty env
 		{
-			name:     "pristine without custom vars",
+			name:     "pristine env with no custom vars leads to empty env",
 			env:      map[string]string{"PATH": "/bin"},
 			pristine: true,
 			output:   map[string]string{},
 		},
-		// pristine env with custom vars only keeps custom vars
 		{
-			name:     "pristine with custom vars",
+			name:     "pristine env with custom vars only keeps custom vars",
 			env:      map[string]string{"PATH": "/bin"},
 			pristine: true,
 			custom:   []string{"GOPATH=/usr/go"},
 			output:   map[string]string{"GOPATH": "/usr/go"},
 		},
-		// custom vars overwrite input vars
 		{
-			name:   "custom and dependency env",
+			name:   "custom vars overwrite input vars",
 			env:    map[string]string{"PATH": "/bin"},
 			custom: []string{"PATH=/usr/bin"},
 			output: map[string]string{"PATH": "/usr/bin"},
 		},
-		// whitelist filters input by key
 		{
-			name:      "whitelist only",
+			name:      "whitelist filters input by key",
 			env:       map[string]string{"GOPATH": "/usr/go", "GO111MODULES": "true", "PATH": "/bin"},
 			whitelist: []string{"GO*"},
 			output:    map[string]string{"GOPATH": "/usr/go", "GO111MODULES": "true"},
 		},
-		// blacklist takes precedence over whitelist
 		{
-			name:      "whitelist and blacklist",
+			name:      "blacklist takes precedence over whitelist",
 			env:       map[string]string{"GOPATH": "/usr/go", "PATH": "/bin", "EDITOR": "vi"},
 			whitelist: []string{"GO*", "EDITOR"},
 			blacklist: []string{"GO*"},
 			output:    map[string]string{"EDITOR": "vi"},
 		},
-		// custom attached after white/black list rules are applied
 		{
-			name:      "blacklist and custom",
+			name:      "custom takes precedence over blacklist",
 			env:       map[string]string{"PATH": "/bin", "EDITOR": "vi"},
 			blacklist: []string{"EDITOR*"},
 			custom:    []string{"EDITOR=nvim"},

--- a/runner_test.go
+++ b/runner_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -103,6 +104,92 @@ func TestRunner_appendSecrets(t *testing.T) {
 			}
 			if ok && value != secretValue {
 				t.Fatalf("values didn't match, expected (%s), got (%s)", secretValue, value)
+			}
+		})
+	}
+}
+
+func TestRunner_configEnv(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name      string
+		env       map[string]string
+		pristine  bool
+		custom    []string
+		whitelist []string
+		blacklist []string
+		output    map[string]string
+	}{
+		// pristine env with no custom vars leads to empty env
+		{
+			name:     "pristine without custom vars",
+			env:      map[string]string{"PATH": "/bin"},
+			pristine: true,
+			output:   map[string]string{},
+		},
+		// pristine env with custom vars only keeps custom vars
+		{
+			name:     "pristine with custom vars",
+			env:      map[string]string{"PATH": "/bin"},
+			pristine: true,
+			custom:   []string{"GOPATH=/usr/go"},
+			output:   map[string]string{"GOPATH": "/usr/go"},
+		},
+		// custom vars overwrite input vars
+		{
+			name:   "custom and dependency env",
+			env:    map[string]string{"PATH": "/bin"},
+			custom: []string{"PATH=/usr/bin"},
+			output: map[string]string{"PATH": "/usr/bin"},
+		},
+		// whitelist filters input by key
+		{
+			name:      "whitelist only",
+			env:       map[string]string{"GOPATH": "/usr/go", "GO111MODULES": "true", "PATH": "/bin"},
+			whitelist: []string{"GO*"},
+			output:    map[string]string{"GOPATH": "/usr/go", "GO111MODULES": "true"},
+		},
+		// blacklist takes precedence over whitelist
+		{
+			name:      "whitelist and blacklist",
+			env:       map[string]string{"GOPATH": "/usr/go", "PATH": "/bin", "EDITOR": "vi"},
+			whitelist: []string{"GO*", "EDITOR"},
+			blacklist: []string{"GO*"},
+			output:    map[string]string{"EDITOR": "vi"},
+		},
+		// custom attached after white/black list rules are applied
+		{
+			name:      "blacklist and custom",
+			env:       map[string]string{"PATH": "/bin", "EDITOR": "vi"},
+			blacklist: []string{"EDITOR*"},
+			custom:    []string{"EDITOR=nvim"},
+			output:    map[string]string{"EDITOR": "nvim", "PATH": "/bin"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Pristine:  &tc.pristine,
+						Blacklist: tc.blacklist,
+						Whitelist: tc.whitelist,
+						Custom:    tc.custom,
+					},
+				},
+			}
+			c := DefaultConfig().Merge(&cfg)
+			r, err := NewRunner(c, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := r.applyConfigEnv(tc.env)
+
+			if !reflect.DeepEqual(result, tc.output) {
+				t.Fatalf("expected: %v\n got: %v", tc.output, result)
 			}
 		})
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -122,7 +122,7 @@ func TestRunner_configEnv(t *testing.T) {
 		output    map[string]string
 	}{
 		{
-			name:     "pristine env with no custom vars leads to empty env",
+			name:     "pristine env with no custom vars yields empty env",
 			env:      map[string]string{"PATH": "/bin"},
 			pristine: true,
 			output:   map[string]string{},

--- a/runner_test.go
+++ b/runner_test.go
@@ -14,12 +14,14 @@ func TestRunner_appendSecrets(t *testing.T) {
 
 	secretValue := "somevalue"
 
-	cases := map[string]struct {
+	tt := []struct {
+		name     string
 		path     string
 		data     *dependency.Secret
 		notFound bool
 	}{
-		"kv1_secret": {
+		{
+			"kv1_secret",
 			"kv/bar",
 			&dependency.Secret{
 				Data: map[string]interface{}{
@@ -28,7 +30,8 @@ func TestRunner_appendSecrets(t *testing.T) {
 			},
 			false,
 		},
-		"kv2_secret": {
+		{
+			"kv2_secret",
 			"secret/data/foo",
 			&dependency.Secret{
 				Data: map[string]interface{}{
@@ -43,7 +46,8 @@ func TestRunner_appendSecrets(t *testing.T) {
 			},
 			false,
 		},
-		"kv2_secret_destroyed": {
+		{
+			"kv2_secret_destroyed",
 			"secret/data/foo",
 			&dependency.Secret{
 				Data: map[string]interface{}{
@@ -58,8 +62,8 @@ func TestRunner_appendSecrets(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		t.Run(fmt.Sprintf("%s", name), func(t *testing.T) {
+	for _, tc := range tt {
+		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
 			cfg := Config{
 				Secrets: &PrefixConfigs{
 					&PrefixConfig{


### PR DESCRIPTION
Fixes: #155

The contents of the Exec.Env block of the config was not being processed when the runner was started.

This PR adds the expected functionality based on the config file [documentation](https://github.com/hashicorp/envconsul/blob/master/README.md#configuration-file).

The logic is a modified version of consul-template's [EnvConfig.Env()](https://github.com/hashicorp/consul-template/blob/master/config/env.go#L106).

The reason for reimplementing it in `envconsul` is that the config data needs to be merged into the env variables received from Consul and Vault.

Flow as proposed:
- If `-pristine` CLI flag or base `pristine` cfg field is set to `false`, load env variables from `os`
- Add env variables from Consul and Vault
- If `exec.env.pristine` in cfg is `true`, clear existing env variables in favor of `exec.env.custom`
- Filter env to whitelisted keys
- Exclude blacklisted keys from env
- Add custom env variables from `exec.env.custom` cfg 