### PR TITLE
Don't panic if secret value isn't string

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -498,11 +498,16 @@ func (r *Runner) appendSecrets(
 
 		if current, ok := env[key]; ok {
 			log.Printf("[DEBUG] (runner) overwriting %s=%q (was %q) from %s", key, value, current, d)
-			env[key] = value.(string)
 		} else {
 			log.Printf("[DEBUG] (runner) setting %s=%q from %s", key, value, d)
-			env[key] = value.(string)
 		}
+
+		val, ok := value.(string)
+		if !ok {
+			log.Printf("[WARN] (runner) skipping key '%s', invalid type for value. got %v, not string", key, reflect.TypeOf(value))
+			continue
+		}
+		env[key] = val
 	}
 
 	return nil

--- a/runner_test.go
+++ b/runner_test.go
@@ -56,6 +56,15 @@ func TestRunner_appendSecrets(t *testing.T) {
 			},
 			true,
 		},
+		"int_secret_skipped": {
+			"kv/foo",
+			&dependency.Secret{
+				Data: map[string]interface{}{
+					"key_field": 1,
+				},
+			},
+			true,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
Fixes: #166 

With this PR the runner will no longer panic if the type of a secret value isn't a string, it will just skip it.