### PR TITLE
Respect no_prefix for Consul keys

### DIFF
--- a/config_prefix.go
+++ b/config_prefix.go
@@ -77,7 +77,8 @@ func (c *PrefixConfig) Finalize() {
 	}
 
 	if c.NoPrefix == nil {
-		c.NoPrefix = config.Bool(false)
+		// Do not set a default value to allow differing defaults for Vault and Consul.
+		// Vault secrets include prefix by default while Consul keys exclude it.
 	}
 
 	if c.Path == nil {

--- a/runner.go
+++ b/runner.go
@@ -387,7 +387,8 @@ func (r *Runner) appendPrefixes(
 			continue
 		}
 
-		if !config.BoolVal(cp.NoPrefix) {
+		// NoPrefix is nil when not set in config. Default to excluding prefix for Consul keys.
+		if cp.NoPrefix != nil && !config.BoolVal(cp.NoPrefix) {
 			pc, ok := r.configPrefixMap[d.String()]
 			if !ok {
 				return fmt.Errorf("missing dependency %s", d)
@@ -489,7 +490,8 @@ func (r *Runner) appendSecrets(
 			continue
 		}
 
-		if !config.BoolVal(cp.NoPrefix) {
+		// NoPrefix is nil when not set in config. Default to including prefix for Vault secrets.
+		if cp.NoPrefix == nil || !config.BoolVal(cp.NoPrefix) {
 			// Replace the path slashes with an underscore.
 			pc, ok := r.configPrefixMap[d.String()]
 			if !ok {

--- a/runner.go
+++ b/runner.go
@@ -378,6 +378,19 @@ func (r *Runner) appendPrefixes(
 			continue
 		}
 
+		if !config.BoolVal(cp.NoPrefix) {
+			pc, ok := r.configPrefixMap[d.String()]
+			if !ok {
+				return fmt.Errorf("missing dependency %s", d)
+			}
+
+			// Replace the invalid path chars such as slashes with underscores
+			path := InvalidRegexp.ReplaceAllString(config.StringVal(pc.Path), "_")
+
+			// Prefix the key value with the path value.
+			key = fmt.Sprintf("%s_%s", path, key)
+		}
+
 		// If the user specified a custom format, apply that here.
 		if config.StringPresent(cp.Format) {
 			key, err = applyTemplate(config.StringVal(cp.Format), key)


### PR DESCRIPTION
Fixes: #190

Previously, the configuration option `no_prefix` was implemented for keys read from Vault but not from Consul.

This PR implements the behavior as stated in the [docs](https://github.com/hashicorp/envconsul/blob/master/README.md): 
> This [noprefix] tells Envconsul to not prefix the keys with their parent "folder".