### PR TITLE
Disable shell interpolation and backtick eval

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -313,8 +313,6 @@ func (r *Runner) Run() (<-chan int, error) {
 	}
 
 	p := shellwords.NewParser()
-	p.ParseEnv = true
-	p.ParseBacktick = true
 	args, err := p.Parse(config.StringVal(r.config.Exec.Command))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed parsing command")


### PR DESCRIPTION
Shell variables were interpolated and backtick blocks evaluated during
the exec/command parsing. It was interpolating the variables using the
original calling process' environment settings without any of the
consul, vault, custom, etc. values injected into it. The backtick blocks
are also executed in the calling processes' environment in the same way.

Neither of these make sense given the execution model of envconsul. Also
the supporting library doesn't really do that great of a job of
mimicking shell semantics. Best path seemed to just remove both.

Fixes #180