### PR TITLE
add -no-prefix cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ prefix {
   format = "custom_{{ key }}"
 
   # This tells Envconsul to not prefix the keys with their parent "folder".
+  # The default for `prefix` (consul) is true, the default for `secret` (vault)
+  # is false. The differing defaults is to maintain backward compatibility.
   no_prefix = false
 
   # This is the path of the key in Consul or Vault from which to read data.

--- a/cli_test.go
+++ b/cli_test.go
@@ -535,6 +535,58 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"no-prefix",
+			[]string{"-prefix", "foo/bar", "-no-prefix"},
+			&Config{
+				Prefixes: &PrefixConfigs{
+					&PrefixConfig{
+						Path: config.String("foo/bar"),
+						NoPrefix: config.Bool(true),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"no-prefix",
+			[]string{"-secret", "foo/bar", "-no-prefix"},
+			&Config{
+				Secrets: &PrefixConfigs{
+					&PrefixConfig{
+						Path: config.String("foo/bar"),
+						NoPrefix: config.Bool(true),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"no-prefix-false",
+			[]string{"-prefix", "foo/bar", "-no-prefix=false"},
+			&Config{
+				Prefixes: &PrefixConfigs{
+					&PrefixConfig{
+						Path: config.String("foo/bar"),
+						NoPrefix: config.Bool(false),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"no-prefix-nil-default",
+			[]string{"-prefix", "foo/bar"},
+			&Config{
+				Prefixes: &PrefixConfigs{
+					&PrefixConfig{
+						Path: config.String("foo/bar"),
+						NoPrefix: nil,
+					},
+				},
+			},
+			false,
+		},
+		{
 			"pristine",
 			[]string{"-pristine"},
 			&Config{


### PR DESCRIPTION
Allows speficying no-prefix globally for all prefixes/secrets from the
command line. Argument handling must be done after standard parsing as
it relies on -prefix and -secret already being set.

Fixes #198