### PR TITLE
Added support for Vault KV2 store with multiple key/value secrets

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -427,6 +427,17 @@ func (r *Runner) appendPrefixes(
 	return nil
 }
 
+func isVaultKv2(data map[string]interface{}) bool {
+	// check for presence of "metadata.version", indicating this value came from Vault
+	// kv version 2
+	if data["metadata"] != nil {
+		metadata := data["metadata"].(map[string]interface{})
+		return metadata["version"] != nil
+	}
+
+	return false
+}
+
 func (r *Runner) appendSecrets(
 	env map[string]string, d *dep.VaultReadQuery, data interface{}) error {
 	var err error
@@ -439,44 +450,40 @@ func (r *Runner) appendSecrets(
 	// Get the PrefixConfig so we can get configuration from it.
 	cp := r.configPrefixMap[d.String()]
 
-	for key, value := range typed.Data {
-		// check for presence of "metadata", indicating this value came from Vault
-		// kv version 2, and we should then use the sub map instead
-		if key == "metadata" {
-			continue
-		}
-
+	valueMap := typed.Data
+	if isVaultKv2(valueMap) {
 		// Vault Secrets KV1 and KV2 return different formats. Here we check the key
 		// value, and if we've found another key called "data" that is of type
 		// map[string]interface, we assume it's KV2 and use the key/value pair from
 		// it, otherwise we assume it's KV1
 		//
-		// value here in KV1 format is a simple string.
-		// value in KV2 format is a map:
-		// map[string]interface {}{
-		//   "key": "value",
+		// In KV1, the JSON looks like
+		// {
+		//		"secretKey1": "value1",
+		//		"secretKey2", "value2"
 		// }
-		if key == "data" {
-			switch value.(type) {
-			case map[string]interface{}:
-				log.Printf("[DEBUG] Found KV2 secret")
-				mapV := value.(map[string]interface{})
+		//
+		// In KV2, the JSON looks like
+		// {
+		//		"data": {
+		//			"secretKey1": "value1",
+		//			"secretKey2", "value2"
+		//		},
+		//		"metadata" : {
+		//			...
+		// 		}
+		// }
+		log.Printf("[DEBUG] Found KV2 secret")
 
-				// assumes this map is only 1 element long, we change the key and value
-				// to match the sub element
-				for k, v := range mapV {
-					key = k
-					value = v
-					break
-				}
-			default:
-				// Only handle the sub data map, do nothing otherwise.
-				// If the secret has been deleted but not destroyed, Vault will return a
-				// response with a nil sub data map, and will not be handled by the
-				// above block
-			}
+		if valueMap["data"] == nil {
+			log.Printf("[DEBUG] KV2 secret is nil or was deleted")
+			valueMap = nil
+		} else {
+			valueMap = valueMap["data"].(map[string]interface{})
 		}
+	}
 
+	for key, value := range valueMap {
 		// Ignore any keys that are empty (not sure if this is even possible in
 		// Vault, but I play defense).
 		if strings.TrimSpace(key) == "" {

--- a/runner_test.go
+++ b/runner_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -197,6 +198,174 @@ func TestRunner_appendSecrets(t *testing.T) {
 			}
 			if ok && value != secretValue2 {
 				t.Fatalf("values didn't match, expected (%s), got (%s)", secretValue2, value)
+			}
+		})
+	}
+}
+
+func TestRunner_appendPrefixes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		path     string
+		noPrefix *bool
+		data     []*dependency.KeyPair
+		keyName  string
+	}{
+		{
+			name:     "false noprefix appends path",
+			path:     "app/my_service",
+			noPrefix: config.Bool(false),
+			data: []*dependency.KeyPair{
+				&dependency.KeyPair{
+					Key:   "mykey",
+					Value: "myValue",
+				},
+			},
+			keyName: "app_my_service_mykey",
+		},
+		{
+			name:     "true noprefix excludes path",
+			path:     "app/my_service",
+			noPrefix: config.Bool(true),
+			data: []*dependency.KeyPair{
+				&dependency.KeyPair{
+					Key:   "mykey",
+					Value: "myValue",
+				},
+			},
+			keyName: "mykey",
+		},
+		{
+			name:     "null noprefix excludes path",
+			path:     "app/my_service",
+			noPrefix: nil,
+			data: []*dependency.KeyPair{
+				&dependency.KeyPair{
+					Key:   "mykey",
+					Value: "myValue",
+				},
+			},
+			keyName: "mykey",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				Prefixes: &PrefixConfigs{
+					&PrefixConfig{
+						Path:     config.String(tc.path),
+						NoPrefix: tc.noPrefix,
+					},
+				},
+			}
+			c := DefaultConfig().Merge(&cfg)
+			r, err := NewRunner(c, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			kvq, err := dependency.NewKVListQuery(tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			env := make(map[string]string)
+			appendError := r.appendPrefixes(env, kvq, tc.data)
+			if appendError != nil {
+				t.Fatalf("got err: %s", appendError)
+			}
+
+			if len(env) > 1 {
+				t.Fatalf("Expected only 1 value in this test")
+			}
+
+			var value string
+			value, ok := env[tc.keyName]
+			if !ok {
+				t.Fatalf("expected (%s) key, but was not found", tc.keyName)
+			}
+			if ok && value != tc.data[0].Value {
+				t.Fatalf("values didn't match, expected (%s), got (%s)", tc.data[0].Value, value)
+			}
+		})
+	}
+}
+
+func TestRunner_configEnv(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name      string
+		env       map[string]string
+		pristine  bool
+		custom    []string
+		whitelist []string
+		blacklist []string
+		output    map[string]string
+	}{
+		{
+			name:     "pristine env with no custom vars yields empty env",
+			env:      map[string]string{"PATH": "/bin"},
+			pristine: true,
+			output:   map[string]string{},
+		},
+		{
+			name:     "pristine env with custom vars only keeps custom vars",
+			env:      map[string]string{"PATH": "/bin"},
+			pristine: true,
+			custom:   []string{"GOPATH=/usr/go"},
+			output:   map[string]string{"GOPATH": "/usr/go"},
+		},
+		{
+			name:   "custom vars overwrite input vars",
+			env:    map[string]string{"PATH": "/bin"},
+			custom: []string{"PATH=/usr/bin"},
+			output: map[string]string{"PATH": "/usr/bin"},
+		},
+		{
+			name:      "whitelist filters input by key",
+			env:       map[string]string{"GOPATH": "/usr/go", "GO111MODULES": "true", "PATH": "/bin"},
+			whitelist: []string{"GO*"},
+			output:    map[string]string{"GOPATH": "/usr/go", "GO111MODULES": "true"},
+		},
+		{
+			name:      "blacklist takes precedence over whitelist",
+			env:       map[string]string{"GOPATH": "/usr/go", "PATH": "/bin", "EDITOR": "vi"},
+			whitelist: []string{"GO*", "EDITOR"},
+			blacklist: []string{"GO*"},
+			output:    map[string]string{"EDITOR": "vi"},
+		},
+		{
+			name:      "custom takes precedence over blacklist",
+			env:       map[string]string{"PATH": "/bin", "EDITOR": "vi"},
+			blacklist: []string{"EDITOR*"},
+			custom:    []string{"EDITOR=nvim"},
+			output:    map[string]string{"EDITOR": "nvim", "PATH": "/bin"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Pristine:  &tc.pristine,
+						Blacklist: tc.blacklist,
+						Whitelist: tc.whitelist,
+						Custom:    tc.custom,
+					},
+				},
+			}
+			c := DefaultConfig().Merge(&cfg)
+			r, err := NewRunner(c, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := r.applyConfigEnv(tc.env)
+
+			if !reflect.DeepEqual(result, tc.output) {
+				t.Fatalf("expected: %v\n got: %v", tc.output, result)
 			}
 		})
 	}


### PR DESCRIPTION
The previous pull request from @catsby supported the Vault KV2 store. However, it assumed that the Vault secret only had a single key. Because Vault stores every secret as a JSON object, a secret can have multiple keys. For instance, a KV2 secret can be:

{
"data": {
"db_username": "john",
"db_password": "smith"
},
"metadata": .....
}

In the previous code, it would just read the "db_username" key and then stop. It should be reading every field inside "data".

I updated the test to include this scenario and also added comments in the code to show the KV1 versus the KV2 JSON structure.