### PR TITLE
don't log values/secrets pulled from vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## envconsul CHANGELOG
 
+SECURITY:
+
+* Don't log secret values pulled from vault.
+
 ## v0.9.1 (Nov 08, 2019)
 
 SECURITY:

--- a/runner.go
+++ b/runner.go
@@ -525,10 +525,10 @@ func (r *Runner) appendSecrets(
 			key = strings.ToUpper(key)
 		}
 
-		if current, ok := env[key]; ok {
-			log.Printf("[DEBUG] (runner) overwriting %s=%q (was %q) from %s", key, value, current, d)
+		if _, ok := env[key]; ok {
+			log.Printf("[DEBUG] (runner) overwriting %s from %s", key, d)
 		} else {
-			log.Printf("[DEBUG] (runner) setting %s=%q from %s", key, value, d)
+			log.Printf("[DEBUG] (runner) setting %s from %s", key, d)
 		}
 
 		val, ok := value.(string)


### PR DESCRIPTION
Internal bug filing. They suggested only including it in TRACE logs but IMO it was improper to log secrets ever and so am removing it.