### PR TITLE
use CGO with arm build (fixes go bug)

### DIFF
--- a/docker/pristine/Dockerfile
+++ b/docker/pristine/Dockerfile
@@ -1,0 +1,8 @@
+### Used for pristine builds
+#
+ARG GOVERSION=latest
+FROM golang:${GOVERSION}
+LABEL maintainer "John Eikenberry <jae@zhar.net>"
+
+RUN apt-get update && \
+    apt-get -y install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu


### PR DESCRIPTION
Build all arm binaries with CGO enabled to address golang bug..

https://github.com/golang/go/issues/32912

Includes arm64 to standardize the platforms supported with those
consul-template supports.

Fixes #227