### PR TITLE
remove -exec-reload-signal from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,10 +483,6 @@ exceptions. There are multiple configuration options related to signals.
   child process to gracefully terminate it. This is the signal that your child
   application listens to for graceful termination.
 
-- `exec.reload_signal` - This signal exists, but it is never used. Configuring
-  it will have no affect, since Envconsul does not send reload signals to  child
-  processes.
-
 ## Examples
 
 ### Redis

--- a/cli.go
+++ b/cli.go
@@ -769,9 +769,6 @@ Options:
   -exec-kill-timeout=<duration>
       Amount of time to wait before force-killing the child
 
-  -exec-reload-signal=<signal>
-      Signal to send when a reload takes place
-
   -exec-splay=<duration>
       Amount of time to wait before sending signals
 


### PR DESCRIPTION
Including the mention in the README about how it isn't used. I think
that is confusing as it is never mentioned anywhere else in the docs.

Fixes #237 