### PR TITLE
renew using unwrapped token

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -740,7 +740,7 @@ func newWatcher(c *Config, clients *dep.ClientSet, once bool) (*watch.Watcher, e
 		RetryFuncDefault: nil,
 		RetryFuncVault:   watch.RetryFunc(c.Vault.Retry.RetryFunc()),
 		VaultGrace:       config.TimeDurationVal(c.Vault.Grace),
-		VaultToken:       config.StringVal(c.Vault.Token),
+		VaultToken:       clients.Vault().Token(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "runner")


### PR DESCRIPTION
Use the client API to get the token instead of accessing directly off
data structure. This ensures you always get the real token both in the
normal case and when working with a wrapped token.

Fixes #222