### PR TITLE
fix issue with secret/prefix entries with no path

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ pid_file = "/path/to/pid"
 
 # This specifies a prefix in Consul to watch. This may be specified multiple
 # times to watch multiple prefixes, and the bottom-most prefix takes
-# precedence, should any values overlap.
+# precedence, should any values overlap. Prefix blocks without the path
+# defined are meaningless and are discarded. If prefix names conflict with
+# secret names, secret names will take precedence.
 prefix {
   # This tells Envconsul to use a custom formatter when printing the key. The
   # value between `{{ key }}` will be replaced with the key.
@@ -340,6 +342,7 @@ prefix {
   no_prefix = false
 
   # This is the path of the key in Consul or Vault from which to read data.
+  # The path field is required or the config block will be ignored.
   path = "foo/bar"
 }
 
@@ -358,7 +361,9 @@ sanitize = false
 
 # This specifies a secret in Vault to watch. This may be specified multiple
 # times to watch multiple secrets, and the bottom-most secret takes
-# precedence, should any values overlap.
+# precedence, should any values overlap. Secret blocks without the path
+# defined are meaningless and are discarded. If secret names conflict with
+# prefix names, secret names will take precedence.
 secret {
   # See `prefix` as they are the same options.
 }

--- a/cli.go
+++ b/cli.go
@@ -795,9 +795,10 @@ Options:
       Path on disk to write the PID of the process
 
   -prefix=<prefix>
-      A prefix to watch, multiple prefixes are merged from left to right, with
-      the right-most result taking precedence, including any values specified
-      with -secret
+      Add a prefix to watch (to the right of configured prefixes), multiple
+      prefixes are merged from left to right, with the right-most result taking
+      precedence, including any values specified with -secret (secrets
+      overrides prefixes)
 
   -pristine
       Only use values retrieved from prefixes and secrets, do not inherit the
@@ -810,9 +811,10 @@ Options:
       Replace invalid characters in keys to underscores
 
   -secret=<prefix>
-      A secret path to watch in Vault, multiple prefixes are merged from left
-      to right, with the right-most result taking precedence, including any
-      values specified with -prefix
+      Add a secret path to watch in Vault (to the right of configured secrets),
+      multiple prefixes are merged from left to right, with the right-most
+      result taking precedence, including any values specified with -prefix
+      (secrets overrides prefixes)
 
   -syslog
       Send the output to syslog instead of standard error and standard out. The

--- a/config_prefix.go
+++ b/config_prefix.go
@@ -144,8 +144,16 @@ func (c *PrefixConfigs) Finalize() {
 		*c = *DefaultPrefixConfigs()
 	}
 
-	for _, t := range *c {
+	// entries without a path are invalid and ignored
+	confs := *c
+	i := 0
+	for _, t := range confs {
+		if config.StringVal(t.Path) == "" {
+			confs = append(confs[:i], confs[i+1:]...)
+			continue
+		}
 		t.Finalize()
+		i++
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1221,6 +1221,10 @@ func TestParse(t *testing.T) {
 			if !reflect.DeepEqual(tc.e, c) {
 				t.Errorf("\nexp: %#v\nact: %#v", tc.e, c)
 			}
+			// should test but at least run to catch big errors
+			if tc.e != nil {
+				c.Finalize()
+			}
 		})
 	}
 }


### PR DESCRIPTION
Issue came up when user had a secret config section with no path set (but had noprefix) and where setting the path on the cli. The documentation on how this was handled was unclear so the user thought it was a bug.

I fixed the issue so that their test would have worked by filtering out the secret config entry with no path (as the path is required).

I also updated the documentation to help clarify how prefix and secret (they use the same code) work.

Fixes #165