### PR TITLE
Change whitelist/blacklist to allowlist/denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ exec {
     # below to inject into the child's runtime environment. If a custom
     # environment variable shares its name with a system environment variable,
     # the custom environment variable takes precedence. Even if pristine,
-    # whitelist, or blacklist is specified, all values in this option
+    # allowlist, or denylist is specified, all values in this option
     # are given to the child process.
     custom = ["PATH=$PATH:/etc/myapp/bin"]
 
@@ -278,16 +278,16 @@ exec {
     # specified, only those environment variables matching the given patterns
     # are exposed to the child process. These strings are matched using Go's
     # glob function, so wildcards are permitted.
-    whitelist = ["CONSUL_*"]
+    allowlist = ["CONSUL_*"]
 
     # This specifies a list of environment variables to exclusively prohibit in
     # the list of environment variables exposed to the child process. If
     # specified, any environment variables matching the given patterns will not
-    # be exposed to the child process, even if they are whitelisted. The values
-    # in this option take precedence over the values in the whitelist.
+    # be exposed to the child process, even if they are in the allowlist. The
+    # values in this option take precedence over the values in the allowlist.
     # These strings are matched using Go's glob function, so wildcards are
     # permitted.
-    blacklist = ["VAULT_*"]
+    denylist = ["VAULT_*"]
   }
 
   # This defines the signal sent to the child process when Envconsul is

--- a/config_test.go
+++ b/config_test.go
@@ -466,7 +466,23 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
-			"exec_env_blacklist",
+			"exec_env_denylist",
+			`exec {
+				env {
+					denylist = ["a", "b"]
+				}
+			 }`,
+			&Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Denylist: []string{"a", "b"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec_env_denylist_deprecated",
 			`exec {
 				env {
 					blacklist = ["a", "b"]
@@ -514,7 +530,23 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
-			"exec_env_whitelist",
+			"exec_env_allowlist",
+			`exec {
+				env {
+					allowlist = ["a", "b"]
+				}
+			 }`,
+			&Config{
+				Exec: &config.ExecConfig{
+					Env: &config.EnvConfig{
+						Allowlist: []string{"a", "b"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"exec_env_allowlist_deprecated",
 			`exec {
 				env {
 					whitelist = ["a", "b"]

--- a/go.sum
+++ b/go.sum
@@ -64,7 +64,6 @@ github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.5.4 h1:1BZvpawXoJCWX6pNtow9+rpEj+3itIlutiqnntI6jOE=
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-rootcerts v1.0.1 h1:DMo4fmknnz0E0evoNYnV48RjWndOsmd6OW+09R3cEP8=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
@@ -99,7 +98,6 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20190730042320-0dc007d98cc8 h1:fLUoZ8cI
 github.com/hashicorp/vault/sdk v0.1.14-0.20190730042320-0dc007d98cc8/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -161,7 +159,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUt
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -228,7 +225,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Updates envconsul to use inclusive language while keeping backward compatibility for the changed configuration option names. Configuration documentation, inline documentation, and variable names are updated to have minimal occurrences of the renamed values.
* `exec.env.blacklist` is renamed to `exec.env.denylist`
* `exec.env.whitelist` is renamed to `exec.env.allowlist`

We encourage practitioners to update their configuration to match these changes, but existing configurations are still backward compatibile.

Resolves #243