### PR TITLE
add support for vault agent token files

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,15 @@ vault {
   # This value can also be specified via the environment variable VAULT_TOKEN.
   token = "abcd1234"
 
+  # This tells Envconsul to load the Vault token from the contents of a file.
+  # If this field is specified:
+  # - by default Envconsul will not try to renew the Vault token, if you want it
+  # to renew you will need to specify renew_token = true as below.
+  # - Envconsul will periodically stat the file and update the token if it has
+  # changed.
+  # vault_agent_token_file = "/path/to/vault/agent/token/file"
+
+
   # This tells Envconsul that the provided token is actually a wrapped
   # token that should be unwrapped using Vault's cubbyhole response wrapping
   # before being used. Please see Vault's cubbyhole response wrapping

--- a/cli.go
+++ b/cli.go
@@ -527,6 +527,10 @@ func (cli *CLI) ParseFlags(args []string) (*Config, []string, bool, bool, error)
 		c.Vault.Token = config.String(s)
 		return nil
 	}), "vault-token", "")
+	flags.Var((funcVar)(func(s string) error {
+		c.Vault.VaultAgentTokenFile = config.String(s)
+		return nil
+	}), "vault-agent-token-file", "")
 
 	flags.Var((funcBoolVar)(func(b bool) error {
 		c.Vault.UnwrapToken = config.Bool(b)
@@ -864,6 +868,9 @@ Options:
 
   -vault-token=<token>
       Sets the Vault API token
+
+  -vault-agent-token-file=<token-file>
+      File to read Vault API token from.
 
   -vault-transport-dial-keep-alive=<duration>
       Sets the amount of time to use for keep-alives

--- a/runner.go
+++ b/runner.go
@@ -766,11 +766,12 @@ func newWatcher(c *Config, clients *dep.ClientSet, once bool) (*watch.Watcher, e
 	log.Printf("[INFO] (runner) creating watcher")
 
 	w, err := watch.NewWatcher(&watch.NewWatcherInput{
-		Clients:         clients,
-		MaxStale:        config.TimeDurationVal(c.MaxStale),
-		Once:            once,
-		RenewVault:      config.StringPresent(c.Vault.Token) && config.BoolVal(c.Vault.RenewToken),
-		RetryFuncConsul: watch.RetryFunc(c.Consul.Retry.RetryFunc()),
+		Clients:             clients,
+		MaxStale:            config.TimeDurationVal(c.MaxStale),
+		Once:                once,
+		RenewVault:          config.StringPresent(c.Vault.Token) && config.BoolVal(c.Vault.RenewToken),
+		VaultAgentTokenFile: config.StringVal(c.Vault.VaultAgentTokenFile),
+		RetryFuncConsul:     watch.RetryFunc(c.Consul.Retry.RetryFunc()),
 		// TODO: Add a sane default retry - right now this only affects "local"
 		// dependencies like reading a file from disk.
 		RetryFuncDefault: nil,


### PR DESCRIPTION
Consul-template already supports this, so it is just a matter of adding
the command line parameter, passing the token on through to the watcher,
documenting and testing.

This was an enhancement request that came in from a client (so no github
issue to close).