### PR TITLE
Add support for Vault namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,11 @@ vault {
   # of the address is required.
   address = "https://vault.service.consul:8200"
 
+  # This is a Vault Enterprise namespace to use for reading/writing secrets.
+  #
+  # This value can also be specified via the environment variable VAULT_NAMESPACE.
+  namespace = "foo"
+
   # This is the token to use when communicating with the Vault server.
   # Like other tools that integrate with Vault, Envconsul makes the
   # assumption that you provide it with a Vault token; it does not have the

--- a/cli.go
+++ b/cli.go
@@ -438,6 +438,11 @@ func (cli *CLI) ParseFlags(args []string) (*Config, []string, bool, bool, error)
 		return nil
 	}), "vault-addr", "")
 
+	flags.Var((funcVar)(func(s string) error {
+		c.Vault.Namespace = config.String(s)
+		return nil
+	}), "vault-namespace", "")
+
 	flags.Var((funcBoolVar)(func(b bool) error {
 		c.Vault.RenewToken = config.Bool(b)
 		return nil
@@ -826,6 +831,9 @@ Options:
 
   -vault-addr=<address>
       Sets the address of the Vault server
+
+  -vault-namespace=<namespace>
+      Sets the Vault namespace
 
   -vault-renew-token
       Periodically renew the provided Vault API token - this defaults to "true"

--- a/cli_test.go
+++ b/cli_test.go
@@ -679,6 +679,16 @@ func TestCLI_ParseFlags(t *testing.T) {
 			false,
 		},
 		{
+			"vault-namespace",
+			[]string{"-vault-namespace", "vault_namespace"},
+			&Config{
+				Vault: &config.VaultConfig{
+					Namespace: config.String("vault_namespace"),
+				},
+			},
+			false,
+		},
+		{
 			"vault-retry",
 			[]string{"-vault-retry"},
 			&Config{

--- a/config_test.go
+++ b/config_test.go
@@ -908,6 +908,18 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"vault_namespace",
+			`vault {
+				namespace = "namespace"
+			}`,
+			&Config{
+				Vault: &config.VaultConfig{
+					Namespace: config.String("namespace"),
+				},
+			},
+			false,
+		},
+		{
 			"vault_token",
 			`vault {
 				token = "token"
@@ -1711,6 +1723,16 @@ func TestDefaultConfig(t *testing.T) {
 			&Config{
 				Vault: &config.VaultConfig{
 					Address: config.String("http://1.2.3.4:8200"),
+				},
+			},
+			false,
+		},
+		{
+			"VAULT_NAMESPACE",
+			"namespace",
+			&Config{
+				Vault: &config.VaultConfig{
+					Namespace: config.String("namespace"),
 				},
 			},
 			false,

--- a/runner.go
+++ b/runner.go
@@ -738,6 +738,7 @@ func newClientSet(c *Config) (*dep.ClientSet, error) {
 
 	if err := clients.CreateVaultClient(&dep.CreateVaultClientInput{
 		Address:                      config.StringVal(c.Vault.Address),
+		Namespace:                    config.StringVal(c.Vault.Namespace),
 		Token:                        config.StringVal(c.Vault.Token),
 		UnwrapToken:                  config.BoolVal(c.Vault.UnwrapToken),
 		SSLEnabled:                   config.BoolVal(c.Vault.SSL.Enabled),


### PR DESCRIPTION
This mirrors [PR#1181 from consul-template](https://github.com/hashicorp/consul-template/pull/1181) to add support for Vault namespaces. It closes #184.