### PR TITLE
correct vault-renew-token docs on defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,8 +432,12 @@ vault {
   # If you are unfamiliar with Vault's architecture, Vault requires tokens be
   # renewed at some regular interval or they will be revoked. Envconsul will
   # automatically renew the token at half the lease duration of the token. The
-  # default value is true, but this option can be disabled if you want to renew
-  # the Vault token using an out-of-band process.
+  # default value is true (exception below), but this option can be disabled if
+  # you want to renew the Vault token using an out-of-band process.
+  # 
+  # There is an exception to the default such that if vault_agent_token_file is
+  # set, either from the command line or the above option, renew_token defaults
+  # to false to avoid renewal conflicts between envconsul and vault-agent.
   #
   # Note that secrets specified as a prefix are always renewed, even if this
   # option is set to false. This option only applies to the top-level Vault

--- a/cli.go
+++ b/cli.go
@@ -900,8 +900,10 @@ Options:
       Sets the address of the Vault server
 
   -vault-renew-token
-      Periodically renew the provided Vault API token - this defaults to "true"
-      and will renew the token at half of the lease duration
+	  Periodically renew the provided Vault API token - this defaults to "true"
+	  and will renew the token at half of the lease duration (unless
+	  vault-agent-token-file is set, then it defaults to false as it is
+	  presumed the vault-agent will take care of renewing)
 
   -vault-retry
       Use retry logic when communication with Vault fails


### PR DESCRIPTION
Use of vault-agent-token-file changes the default of vault-renew-token to false. This was a change in consul-template's behavior to fix a bug and the doc update was missed due to the indirect nature of the change.

Fixes #255