### PR TITLE
set consul-tempalte's vault default lease

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -728,6 +728,10 @@ func (r *Runner) init() error {
 		return fmt.Errorf("runner: %s", err)
 	}
 
+	// Set's consul-template's default vault lease duration
+	// this will go away with hashicat as it eliminates this setting
+	dep.SetVaultDefaultLeaseDuration(config.TimeDurationVal(r.config.Vault.DefaultLeaseDuration))
+
 	// Create the watcher
 	watcher, err := newWatcher(r.config, clients, r.once)
 	if err != nil {


### PR DESCRIPTION
Consul-template grew a configurable default lease time for vault but
it did it in a way that made envconsul use a 0 lease time.

This fixes that by setting the default lease time to the new default as
specified in vault's config (in consul-template).

Fixes #272