### PR TITLE
skip logging Go's runtime scheduler signals

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -142,7 +142,11 @@ func (cli *CLI) Run(args []string) int {
 				return logError(err, code)
 			}
 		case s := <-cli.signalCh:
-			log.Printf("[DEBUG] (cli) receiving signal %q", s)
+			switch s {
+			case RuntimeSig:
+			default: // filter out RuntimeSig, as it is used by the scheduler and noisy
+				log.Printf("[DEBUG] (cli) receiving signal %q", s)
+			}
 
 			switch s {
 			case *cfg.ReloadSignal:


### PR DESCRIPTION
Scheduler uses SIGURG to pre-emtp and can't filter them itself as there
is no way to discern scheduler signals from others. Skip logging them to
keep them out of logs as they are confusing (they show up as 'urgent I/O
condition').

Fixes #285