### PR TITLE
converted to use go-hclog for logging

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -225,6 +224,7 @@ func (c *Config) Merge(o *Config) *Config {
 
 // Parse parses the given string contents as a config
 func Parse(s string) (*Config, error) {
+	logger := namedLogger("parse")
 	var shadow interface{}
 	if err := hcl.Decode(&shadow, s); err != nil {
 		return nil, errors.Wrap(err, "error decoding config")
@@ -259,9 +259,9 @@ func Parse(s string) (*Config, error) {
 		"ssl",
 	})
 	if auth, ok := parsed["auth"]; ok {
-		log.Printf("[WARN] auth is now a child stanza inside consul instead of a " +
-			"top-level stanza. Update your configuration files and change auth {} " +
-			"to consul { auth { ... } } instead.")
+		logger.Warn("auth is now a child stanza inside consul instead of a " +
+			"top-level stanza. Update your configuration files and change " +
+			"auth {} to consul { auth { ... } } instead.")
 		consul, ok := parsed["consul"].(map[string]interface{})
 		if !ok {
 			consul = map[string]interface{}{}
@@ -271,12 +271,12 @@ func Parse(s string) (*Config, error) {
 		delete(parsed, "auth")
 	}
 	if _, ok := parsed["path"]; ok {
-		log.Printf("[WARN] path is no longer a key in the configuration. Please " +
+		logger.Warn("path is no longer a key in the configuration. Please " +
 			"remove it and use the CLI option instead.")
 		delete(parsed, "path")
 	}
 	if splay, ok := parsed["splay"]; ok {
-		log.Printf("[WARN] splay is now a child stanza for exec instead of a "+
+		logger.Warn("splay is now a child stanza for exec instead of a "+
 			"top-level key. Update your configuration files and change "+
 			"splay = \"%s\" to exec { splay = \"%s\" } instead.", splay, splay)
 		exec, ok := parsed["exec"].(map[string]interface{})
@@ -288,10 +288,10 @@ func Parse(s string) (*Config, error) {
 		delete(parsed, "splay")
 	}
 	if retry, ok := parsed["retry"]; ok {
-		log.Printf("[WARN] retry is now a child stanza for both consul and vault " +
-			"instead of a top-level stanza. Update your configuration files and " +
-			"change retry {} to consul { retry { ... } } and vault { retry { ... } } " +
-			"instead.")
+		logger.Warn("retry is now a child stanza for both consul and vault " +
+			"instead of a top-level stanza. Update your configuration files " +
+			"and change retry {} to consul { retry { ... } } and " +
+			"vault { retry { ... } } instead.")
 
 		consul, ok := parsed["consul"].(map[string]interface{})
 		if !ok {
@@ -317,10 +317,10 @@ func Parse(s string) (*Config, error) {
 		delete(parsed, "retry")
 	}
 	if ssl, ok := parsed["ssl"]; ok {
-		log.Printf("[WARN] ssl is now a child stanza for both consul and vault " +
-			"instead of a top-level stanza. Update your configuration files and " +
-			"change ssl {} to consul { ssl { ... } } and vault { ssl { ... } } " +
-			"instead.")
+		logger.Warn("ssl is now a child stanza for both consul and vault " +
+			"instead of a top-level stanza. Update your configuration files " +
+			"and change ssl {} to consul { ssl { ... } } and " +
+			"vault { ssl { ... } } instead.")
 
 		consul, ok := parsed["consul"].(map[string]interface{})
 		if !ok {
@@ -341,7 +341,7 @@ func Parse(s string) (*Config, error) {
 		delete(parsed, "ssl")
 	}
 	if timeout, ok := parsed["timeout"]; ok {
-		log.Printf("[WARN] timeout is now a child stanza for exec instead of a "+
+		logger.Warn("timeout is now a child stanza for exec instead of a "+
 			"top-level key. Update your configuration files and change "+
 			"timeout = \"%s\" to exec { kill_timeout = \"%s\" } instead.",
 			timeout, timeout)
@@ -354,9 +354,9 @@ func Parse(s string) (*Config, error) {
 		delete(parsed, "timeout")
 	}
 	if token, ok := parsed["token"]; ok {
-		log.Printf("[WARN] token is now a child stanza inside consul instead of a " +
-			"top-level key. Update your configuration files and change token = \"...\" " +
-			"to consul { token = \"...\" } instead.")
+		logger.Warn("token is now a child stanza inside consul instead of a " +
+			"top-level key. Update your configuration files and change " +
+			"token = \"...\" to consul { token = \"...\" } instead.")
 		consul, ok := parsed["consul"].(map[string]interface{})
 		if !ok {
 			consul = map[string]interface{}{}
@@ -385,11 +385,11 @@ func Parse(s string) (*Config, error) {
 		Result:      &c,
 	})
 	if err != nil {
-		log.Printf("%#v", parsed)
+		logger.Debug(fmt.Sprintf("%#v", parsed))
 		return nil, errors.Wrap(err, "mapstructure decoder creation failed")
 	}
 	if err := decoder.Decode(parsed); err != nil {
-		log.Printf("%#v", parsed)
+		logger.Debug(fmt.Sprintf("%#v", parsed))
 		return nil, errors.Wrap(err, "mapstructure decode failed")
 	}
 
@@ -401,7 +401,7 @@ func Parse(s string) (*Config, error) {
 func Must(s string) *Config {
 	c, err := Parse(s)
 	if err != nil {
-		log.Fatal(err)
+		namedLogger("parse").Error(err.Error())
 	}
 	return c
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/consul-template v0.29.0
 	github.com/hashicorp/go-gatedio v0.5.0
+	github.com/hashicorp/go-hclog v1.2.1
 	github.com/hashicorp/hcl v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
@@ -28,7 +29,6 @@ require (
 	github.com/hashicorp/cronexpr v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.4 // indirect

--- a/runner.go
+++ b/runner.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -90,7 +89,7 @@ type Runner struct {
 
 // NewRunner accepts a config, command, and boolean value for once mode.
 func NewRunner(config *Config, once bool) (*Runner, error) {
-	log.Printf("[INFO] (runner) creating new runner (once: %v)", once)
+	namedLogger("runner").Info("creating new runner", "once:", once)
 
 	runner := &Runner{
 		config: config,
@@ -107,7 +106,8 @@ func NewRunner(config *Config, once bool) (*Runner, error) {
 // Start creates a new runner and begins watching dependencies and quiescence
 // timers. This is the main event loop and will block until finished.
 func (r *Runner) Start() {
-	log.Printf("[INFO] (runner) starting")
+	logger := namedLogger("runner")
+	logger.Info("starting")
 
 	// Create the pid before doing anything.
 	if err := r.storePid(); err != nil {
@@ -140,7 +140,7 @@ func (r *Runner) Start() {
 
 			// If we are waiting for quiescence, setup the timers
 			if config.BoolVal(r.config.Wait.Enabled) {
-				log.Printf("[INFO] (runner) quiescence timers starting")
+				logger.Info("quiescence timers starting")
 				r.minTimer = time.After(config.TimeDurationVal(r.config.Wait.Min))
 				if r.maxTimer == nil {
 					r.maxTimer = time.After(config.TimeDurationVal(r.config.Wait.Max))
@@ -148,10 +148,10 @@ func (r *Runner) Start() {
 				continue
 			}
 		case <-r.minTimer:
-			log.Printf("[INFO] (runner) quiescence minTimer fired")
+			logger.Info("quiescence minTimer fired")
 			r.minTimer, r.maxTimer = nil, nil
 		case <-r.maxTimer:
-			log.Printf("[INFO] (runner) quiescence maxTimer fired")
+			logger.Info("quiescence maxTimer fired")
 			r.minTimer, r.maxTimer = nil, nil
 		case err := <-r.watcher.ErrCh():
 			// Intentionally do not send the error back up to the runner. Eventually,
@@ -161,7 +161,7 @@ func (r *Runner) Start() {
 			// if err.Contains(Something) {
 			//   errCh <- err
 			// }
-			log.Printf("[ERR] (runner) watcher reported error: %s", err)
+			logger.Error("watcher reported error:", err)
 			if r.once {
 				r.ErrCh <- err
 				return
@@ -169,7 +169,7 @@ func (r *Runner) Start() {
 		case code := <-exitCh:
 			r.ExitCh <- code
 		case <-r.DoneCh:
-			log.Printf("[INFO] (runner) received finish")
+			logger.Info("received finish")
 			return
 		}
 
@@ -200,13 +200,14 @@ func (r *Runner) Stop() {
 		return
 	}
 
-	log.Printf("[INFO] (runner) stopping")
+	logger := namedLogger("runner")
+	logger.Info("stopping")
 	r.stopWatcher()
 	r.stopChild()
 
 	if err := r.deletePid(); err != nil {
-		log.Printf("[WARN] (runner) could not remove pid at %#v: %s",
-			r.config.PidFile, err)
+		logger.Warn(fmt.Sprintf("could not remove pid at %#v: %s",
+			r.config.PidFile, err))
 	}
 
 	r.stopped = true
@@ -218,7 +219,7 @@ func (r *Runner) Stop() {
 func (r *Runner) Receive(d dep.Dependency, data interface{}) {
 	r.dependenciesLock.Lock()
 	defer r.dependenciesLock.Unlock()
-	log.Printf("[DEBUG] (runner) receiving dependency %s", d)
+	namedLogger("runner").Debug("receiving dependency %s", d)
 	r.data[d.String()] = data
 }
 
@@ -236,7 +237,8 @@ func (r *Runner) Signal(s os.Signal) error {
 // Run executes and manages the child process with the correct environment. The
 // current environment is also copied into the child process environment.
 func (r *Runner) Run() (<-chan int, error) {
-	log.Printf("[INFO] (runner) running")
+	logger := namedLogger("runner")
+	logger.Info("running")
 
 	env := make(map[string]string)
 
@@ -251,7 +253,7 @@ func (r *Runner) Run() (<-chan int, error) {
 	for _, d := range r.dependencies {
 		data, ok := r.data[d.String()]
 		if !ok {
-			log.Printf("[INFO] (runner) missing data for %s", d)
+			logger.Info("missing data for", d)
 			return nil, nil
 		}
 
@@ -268,16 +270,16 @@ func (r *Runner) Run() (<-chan int, error) {
 	}
 
 	// Print the final environment
-	log.Printf("[TRACE] Environment:")
+	logger.Trace("Environment:")
 	for k, v := range env {
-		log.Printf("[TRACE]   %s=%q", k, v)
+		logger.Trace(fmt.Sprintf("%s=%q", k, v))
 	}
 
 	// If the resulting map is the same, do not do anything. We use a length
 	// check first to get a small performance increase if something has changed
 	// so we don't immediately delegate to reflect which is slow.
 	if len(r.env) == len(env) && reflect.DeepEqual(r.env, env) {
-		log.Printf("[INFO] (runner) environment was the same")
+		logger.Info("environment was the same")
 		return nil, nil
 	}
 
@@ -285,7 +287,7 @@ func (r *Runner) Run() (<-chan int, error) {
 	r.env = env
 
 	if r.child != nil {
-		log.Printf("[INFO] (runner) stopping existing child process")
+		logger.Info("stopping existing child process")
 		r.stopChild()
 	}
 
@@ -491,7 +493,8 @@ func (r *Runner) appendServices(env map[string]string, d *dep.CatalogServiceQuer
 }
 
 func (r *Runner) appendPrefixes(
-	env map[string]string, d *dep.KVListQuery, data interface{}) error {
+	env map[string]string, d *dep.KVListQuery, data interface{},
+) error {
 	var err error
 
 	typed, ok := data.([]*dep.KeyPair)
@@ -543,11 +546,12 @@ func (r *Runner) appendPrefixes(
 			key = strings.ToUpper(key)
 		}
 
+		logger := namedLogger("runner")
 		if current, ok := env[key]; ok {
-			log.Printf("[DEBUG] (runner) overwriting %s=%q (was %q) from %s", key, value, current, d)
+			logger.Debug(fmt.Sprintf("overwriting %s=%q (was %q) from %s", key, value, current, d))
 			env[key] = value
 		} else {
-			log.Printf("[DEBUG] (runner) setting %s=%q from %s", key, value, d)
+			logger.Debug(fmt.Sprintf("setting %s=%q from %s", key, value, d))
 			env[key] = value
 		}
 	}
@@ -567,8 +571,10 @@ func isVaultKv2(data map[string]interface{}) bool {
 }
 
 func (r *Runner) appendSecrets(
-	env map[string]string, d *dep.VaultReadQuery, data interface{}) error {
+	env map[string]string, d *dep.VaultReadQuery, data interface{},
+) error {
 	var err error
+	logger := namedLogger("runner")
 
 	typed, ok := data.(*dep.Secret)
 	if !ok {
@@ -601,10 +607,10 @@ func (r *Runner) appendSecrets(
 		//			...
 		// 		}
 		// }
-		log.Printf("[DEBUG] Found KV2 secret")
+		logger.Debug("Found KV2 secret")
 
 		if valueMap["data"] == nil {
-			log.Printf("[DEBUG] KV2 secret is nil or was deleted")
+			logger.Debug("KV2 secret is nil or was deleted")
 			valueMap = nil
 		} else {
 			valueMap = valueMap["data"].(map[string]interface{})
@@ -640,7 +646,7 @@ func (r *Runner) appendSecrets(
 		if applyPerKeyFormat {
 			keyFormat, ok := keyFormats[key]
 			if !ok {
-				log.Printf("[DEBUG] (runner) skipping key '%s' since it is not listed in configuration", key)
+				logger.Debug(fmt.Sprintf("skipping key '%s' since it is not listed in configuration", key))
 				continue
 			}
 			if config.StringPresent(keyFormat.Format) {
@@ -686,14 +692,14 @@ func (r *Runner) appendSecrets(
 		}
 
 		if _, ok := env[key]; ok {
-			log.Printf("[DEBUG] (runner) overwriting %s from %s", key, d)
+			logger.Debug(fmt.Sprintf("overwriting %s from %s", key, d))
 		} else {
-			log.Printf("[DEBUG] (runner) setting %s from %s", key, d)
+			logger.Debug(fmt.Sprintf("setting %s from %s", key, d))
 		}
 
 		val, ok := value.(string)
 		if !ok {
-			log.Printf("[WARN] (runner) skipping key '%s', invalid type for value. got %v, not string", key, reflect.TypeOf(value))
+			logger.Warn(fmt.Sprintf("skipping key '%s', invalid type for value. got %v, not string", key, reflect.TypeOf(value)))
 			continue
 		}
 		env[key] = val
@@ -714,7 +720,8 @@ func (r *Runner) init() error {
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] (runner) final config: %s", result)
+	logger := namedLogger("runner")
+	logger.Debug("final config:", result)
 
 	// Create the clientset
 	clients, err := newClientSet(r.config)
@@ -780,7 +787,7 @@ func (r *Runner) init() error {
 			return err
 		}
 
-		log.Printf("[INFO] looking at vault %s", path)
+		logger.Info("looking at vault", "path", path)
 		d, err := dep.NewVaultReadQuery(path)
 		if err != nil {
 			return err
@@ -794,7 +801,7 @@ func (r *Runner) init() error {
 
 func (r *Runner) stopWatcher() {
 	if r.watcher != nil {
-		log.Printf("[DEBUG] (runner) stopping watcher")
+		namedLogger("runner").Debug("stopping watcher")
 		r.watcher.Stop()
 	}
 }
@@ -804,7 +811,7 @@ func (r *Runner) stopChild() {
 	defer r.childLock.RUnlock()
 
 	if r.child != nil {
-		log.Printf("[DEBUG] (runner) stopping child process")
+		namedLogger("runner").Debug("stopping child process")
 		r.child.Stop()
 	}
 }
@@ -816,9 +823,9 @@ func (r *Runner) storePid() error {
 		return nil
 	}
 
-	log.Printf("[INFO] creating pid file at %q", path)
+	namedLogger("runner").Info("creating pid file at %q", path)
 
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o666)
 	if err != nil {
 		return fmt.Errorf("runner: could not open pid file: %s", err)
 	}
@@ -839,7 +846,7 @@ func (r *Runner) deletePid() error {
 		return nil
 	}
 
-	log.Printf("[DEBUG] removing pid file at %q", path)
+	namedLogger("runner").Debug("removing pid file at %q", path)
 
 	stat, err := os.Stat(path)
 	if err != nil {
@@ -912,7 +919,7 @@ func newClientSet(c *Config) (*dep.ClientSet, error) {
 
 // newWatcher creates a new watcher.
 func newWatcher(c *Config, clients *dep.ClientSet, once bool) (*watch.Watcher, error) {
-	log.Printf("[INFO] (runner) creating watcher")
+	namedLogger("runner").Info("creating watcher")
 
 	w, err := watch.NewWatcher(&watch.NewWatcherInput{
 		Clients:             clients,


### PR DESCRIPTION
Pretty straight forward, simple conversion.

2 basic steps. 
1. changing all the levels (eg. log.Printf("[Warn]...")) to their functional equivalents (eg. logger.Warn("..."))
2. changing the inline sub-section names used in the original (eg. "(runner)") with named sub-loggers (eg. logger.Named("runner")).

I *did not* try to convert things to use the structured approach that hclog takes except in a very few places and instead kept most entries as simple strings. I plan on using the structured more as things move forward but really just wanted a basic conversion at this point. Get the ball rolling.. so to speak.