### PR TITLE
have standard 'log' package output to hclog + ERROR level tweaks

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/signal"
 	"strings"
@@ -790,6 +791,12 @@ func (cli *CLI) setupLogger(conf *Config) error {
 	})
 
 	hclog.SetDefault(logger)
+	// XXX consul-template still uses 'log' package
+	// XXX this gets 'log' playing mostly nice with hclog
+	// XXX remove after consul-template uses hclog??
+	log.SetFlags(0)                      // only log the message
+	log.SetOutput(logger.StandardWriter( // send message to hclog
+		&hclog.StandardLoggerOptions{InferLevels: true}))
 	return nil
 }
 


### PR DESCRIPTION
consult-template is still using the standard log package

These tweaks limits it to logging just the message and handing that to hclog. It makes it look mostly like it is an normal log entry. Only diff is that it uses different notation for subsections.

Might be useful just to keep as it makes using the standard log package work easily with hclog.

Plus some tweaks to deal with error level indicated by either ERR or ERROR.