### PR TITLE
add missing call to set module level variable

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -746,9 +746,10 @@ func (r *Runner) init() error {
 		return fmt.Errorf("runner: %s", err)
 	}
 
-	// Set's consul-template's default vault lease duration
-	// this will go away with hashicat as it eliminates this setting
+	// Set's consul-template's default vault lease duration and renewal thresh
+	// these will go away with hashicat as it will eliminate the setting
 	dep.SetVaultDefaultLeaseDuration(config.TimeDurationVal(r.config.Vault.DefaultLeaseDuration))
+	dep.SetVaultLeaseRenewalThreshold(valueFrom(r.config.Vault.LeaseRenewalThreshold))
 
 	// Create the watcher
 	watcher, err := newWatcher(r.config, clients, r.once)


### PR DESCRIPTION
A default value was changed to be configurable by changing the fixed
const into a module level variable that was set at runtime. When updated
to the new consul-template version this setting of the new variable was
missed. This adds it.

Fixed #310 

Note there are no tests as this section of code has none currently and it will all get reworked as part of the hashicat update anyways, so no use it adding a bunch of testing at this point.